### PR TITLE
docs: group tutorials by topic in navigation

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -117,6 +117,12 @@
                       "tutorials/following_a_git_commit_to_runtime_environments",
                       "tutorials/tracing_a_production_incident_back_to_git_commits"
                     ]
+                  },
+                  {
+                    "group": "Security",
+                    "pages": [
+                      "tutorials/unauthorized_iac_changes"
+                    ]
                   }
                 ]
               },


### PR DESCRIPTION
Groups the Tutorials section in the sidebar into four sub-groups:

- **Getting started** — Get familiar with Kosli, CLI & HTTP proxy
- **Attesting** — Attest Snyk scans, Custom CTRF attestation type
- **Reporting environments** — Report AWS environments, Report Kubernetes environments
- **Querying & tracing** — Querying Kosli, From commit to production, Tracing a production incident

A Security group (unauthorized Terraform changes) will be added once PR #20 is merged.

All tutorial page URLs are unchanged — Mintlify resolves them from file paths, not navigation structure.