### PR TITLE
style: apply Kosli brand colors and step component styles

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -3,9 +3,9 @@
   "theme": "mint",
   "name": "Kosli Documentation",
   "colors": {
-    "primary": "#2E6C47",
-    "light": "#67AA7C",
-    "dark": "#67AA7C"
+    "primary": "#1C4BC6",
+    "light": "#ABBDFF",
+    "dark": "#1C4BC6"
   },
   "fonts": {
     "family": "IBM Plex Sans"
@@ -27,8 +27,8 @@
   "background": {
     "decoration": "windows",
     "color": {
-      "dark": "#121C2A",
-      "light": "#F2F3F6"
+      "dark": "#111A26",
+      "light": "#F6F8FC"
     }
   },
   "metadata": {

--- a/style.css
+++ b/style.css
@@ -1,0 +1,17 @@
+/*
+ * Kosli docs custom styles
+ * Applied on top of Mintlify's mint theme.
+ */
+
+
+
+/* ─── Steps component ─────────────────────────────────────────────────────── */
+/*
+ * Step number circles use Tailwind's bg-gray-50 (#F9FAFB) which is nearly
+ * invisible against the light page background (#F6F8FC).
+ * Target via the confirmed data-component-part attribute.
+ */
+[data-component-part="step-number"] > div {
+  background-color: #CFD8FF !important;
+  color: #111A26 !important;
+}


### PR DESCRIPTION
## Summary

- Switch primary accent color from green to brand blue (`#1C4BC6`), aligning with Kosli's official brand guidelines
- Set `light`/`dark` color variants (`#ABBDFF` / `#1C4BC6`) and exact background surface colors (`#111A26` dark, `#F6F8FC` light)
- Add `style.css` with step number circle override — Blue 200 (`#CFD8FF`) background with Navy Dark (`#111A26`) text, fixing near-invisible circles in light mode

## Test plan

- [x] Run `mint dev` and verify primary color (links, nav active states, buttons) is blue not green
- [x] Check light mode step number circles are visible and styled with soft blue
- [x] Check dark mode is unaffected
- [x] Run `mint a11y` and confirm no regressions beyond the known false positive