### PR TITLE
ci: add PR quality workflow for conventional commit title validation

### DIFF
--- a/.github/workflows/pr-quality.yml
+++ b/.github/workflows/pr-quality.yml
@@ -1,0 +1,42 @@
+name: PR Quality Checks
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
+
+jobs:
+  validate-title:
+    name: Validate PR Title
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    steps:
+      - name: Check PR title follows Conventional Commit format
+        uses: amannn/action-semantic-pull-request@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          # Configure allowed types (based on conventional commits)
+          types: |
+            feat
+            fix
+            docs
+            style
+            refactor
+            perf
+            test
+            build
+            ci
+            chore
+            revert
+          # Don't require a scope (e.g., "feat(<scope>): ...")
+          requireScope: false
+          # Don't allow subject to start with uppercase letter
+          subjectPattern: ^(?![A-Z]).+$
+          subjectPatternError: |
+            The subject (description) should start with a lowercase letter.
+            Example: "feat(api): add new endpoint" (not "feat(api): Add new endpoint")


### PR DESCRIPTION
## Summary

- Ports `.github/workflows/pr-quality.yml` from `kosli-dev/terraform-provider-kosli`
- Validates PR titles follow Conventional Commits format using `amannn/action-semantic-pull-request@v6`
- Allowed types: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`, `revert`
- Scope is optional
- Enforces lowercase subject (no uppercase first letter)

Closes #28
