### PR TITLE
fix: correct helm-docs download filename to Linux_x86_64

### DIFF
--- a/.github/workflows/update-cli-docs.yml
+++ b/.github/workflows/update-cli-docs.yml
@@ -67,7 +67,7 @@ jobs:
 
       - name: Install helm-docs
         run: |
-          curl -sL https://github.com/norwoodj/helm-docs/releases/download/v1.14.2/helm-docs_1.14.2_linux_amd64.deb --output helm-docs.deb
+          curl -sL https://github.com/norwoodj/helm-docs/releases/download/v1.14.2/helm-docs_1.14.2_Linux_x86_64.deb --output helm-docs.deb
           sudo dpkg -i helm-docs.deb
           rm helm-docs.deb
 


### PR DESCRIPTION
Fixes the helm-docs install step in the Update Reference Docs workflow. The download URL used `linux_amd64` but the actual release asset is named `Linux_x86_64`.