### PR TITLE
fix: correct docs.json syntax error in Helm Reference navigation

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -215,15 +215,6 @@
                 "group": "kosli allow",
                 "pages": [
                   "client_reference/kosli_allow_artifact"
-                "item": "Helm Reference",
-                "icon": "helm",
-                "groups": [
-                  {
-                    "group": "Helm Charts",
-                    "pages": [
-                      "helm/k8s_reporter"
-                    ]
-                  }
                 ]
               },
               {
@@ -382,18 +373,6 @@
             ]
           },
           {
-            "item": "Helm Reference",
-            "icon": "helm",
-            "groups": [
-              {
-                "group": "Helm Charts",
-                "pages": [
-                  "helm/k8s_reporter"
-                ]
-              }
-            ]
-          },
-          {
             "item": "API Reference",
             "icon": "code",
             "groups": [
@@ -402,6 +381,18 @@
                 "pages": [
                   "api-reference/endpoint/list_environments",
                   "api-reference/endpoint/put_environment"
+                ]
+              }
+            ]
+          },
+          {
+            "item": "Helm Reference",
+            "icon": "layer-group",
+            "groups": [
+              {
+                "group": "Helm Charts",
+                "pages": [
+                  "helm/k8s_reporter"
                 ]
               }
             ]


### PR DESCRIPTION
## Summary

- Removes Helm Reference tab fragment that was incorrectly nested inside the `kosli allow` pages array, causing a JSON syntax error
- Adds a properly structured Helm Reference tab at the correct top-level tabs position (after API Reference)
- Updates icon from `helm` to `layer-group` (valid Font Awesome name)
