### PR TITLE
fix: repair broken links in getting_started

### DIFF
--- a/getting_started/artifacts.md
+++ b/getting_started/artifacts.md
@@ -57,7 +57,7 @@ When this flag is used, a CLI command:
 
 We recommend using the `KOSLI_DRY_RUN` environment variable to automatically set the `--dry-run` flag.
 This will allow you to instantly turn off all Kosli CLI commands if Kosli is down, as detailed in
-[this tutorial](/tutorials/what_do_i_do_if_kosli_is_down/).
+[this tutorial](/troubleshooting/what_do_i_do_if_kosli_is_down).
 
 The `--dry-run` flag is also useful when trying commands locally. For example:
 

--- a/getting_started/flows.md
+++ b/getting_started/flows.md
@@ -23,11 +23,12 @@ kosli create flow process-a --description "My SW delivery process" \
 
 When creating a Flow, you can optionally provide a `Flow Template`. This template defines the necessary steps within the business or software process represented by a Kosli Flow. The compliance of Flow trails and artifacts will be assessed using the template.
 
-A Flow template is a YAML file following the syntax outlined in the [flow template spec](/template_ref).
+A Flow template is a YAML file following the syntax outlined in the [flow template spec](/template-reference/flow_template).
 
 Here is an example:
 
 ```yml sw-delivery-template.yml
+# yaml-language-server: $schema=https://kosli.mintlify.app/schemas/flow-template.json
 version: 1
 trail:
   attestations:


### PR DESCRIPTION
## Summary

- `getting_started/flows.md` — fixed dead link `/template_ref` → `/template-reference/flow_template` and added JSON Schema reference comment to the YAML example
- `getting_started/artifacts.md` — fixed dead link `/tutorials/what_do_i_do_if_kosli_is_down/` → `/troubleshooting/what_do_i_do_if_kosli_is_down`

## Test plan

- [x] `mint broken-links` no longer flags these files