### PR TITLE
chore: add CODEOWNERS file for customer success team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*  @kosli-dev/custumer-success
+*  @kosli-dev/customer-success


### PR DESCRIPTION
Add CODEOWNERS for docs and notify reviewers. Needs amending permissions and add CS team group as Admin or at least writer.