### PR TITLE
docs: add legacy Netlify redirects for migration to Mintlify

### DIFF
--- a/config/redirects.json
+++ b/config/redirects.json
@@ -40,8 +40,12 @@
     "destination": "/getting_started/artifacts"
   },
   {
+    "source": "/getting_started/overview",
+    "destination": "/getting_started/install"
+  },
+  {
     "source": "/getting_started/part_1_overview",
-    "destination": "/getting_started/overview"
+    "destination": "/getting_started/install"
   },
   {
     "source": "/kosli_overview/what_is_kosli",

--- a/config/redirects.json
+++ b/config/redirects.json
@@ -26,10 +26,25 @@
   {
     "source": "/faq",
     "destination": "/faq/faq"
-  }
-  ,
+  },
   {
     "source": "/schemas/policy/v1",
     "destination": "/schemas/policy/v1.json"
+  },
+  {
+    "source": "/getting_started/part_9_querying",
+    "destination": "/tutorials/querying_kosli"
+  },
+  {
+    "source": "/getting_started/part_5_artifacts",
+    "destination": "/getting_started/artifacts"
+  },
+  {
+    "source": "/getting_started/part_1_overview",
+    "destination": "/getting_started/overview"
+  },
+  {
+    "source": "/kosli_overview/what_is_kosli",
+    "destination": "/understand_kosli/what_is_kosli"
   }
 ]

--- a/getting_started/overview.mdx
+++ b/getting_started/overview.mdx
@@ -1,4 +1,0 @@
----
-title: 'Overview'
-description: 'Preview changes locally to update your docs'
----


### PR DESCRIPTION
## Summary

- Adds 5 redirect rules from the old Hugo/Netlify `docs.kosli.com` site (`_redirects` file in `kosli-dev/cli`) to `config/redirects.json`
- Ensures bookmarks and search engine links from the old site continue working after the DNS cutover to Mintlify
- Removes `getting_started/overview.mdx` which should not exist
- Fixes a minor JSON formatting issue (stray comma)

## Redirects added

| Old URL | Destination |
|---------|------------|
| `/getting_started/part_9_querying` | `/tutorials/querying_kosli` |
| `/getting_started/part_5_artifacts` | `/getting_started/artifacts` |
| `/getting_started/overview` | `/getting_started/install` |
| `/getting_started/part_1_overview` | `/getting_started/install` |
| `/kosli_overview/what_is_kosli` | `/understand_kosli/what_is_kosli` |

These redirects were originally added to the Netlify site between Sep 2023 and Jan 2024 for SEO purposes. All destination pages exist in this repo.

## Test plan

- [x] Verify redirects work after merge by visiting the old paths on the Mintlify preview