### PR TITLE
docs: update domain from kosli.mintlify.app to docs.kosli.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > [!WARNING]
 > This documentation is still a work in progress and is not yet the official Kosli documentation.
 
-Source for [kosli.mintlify.app](https://kosli.mintlify.app), built with [Mintlify](https://mintlify.com).
+Source for [docs.kosli.com](https://docs.kosli.com), built with [Mintlify](https://mintlify.com).
 
 ## Development
 

--- a/getting_started/attestations.md
+++ b/getting_started/attestations.md
@@ -17,7 +17,7 @@ Let's take a look at this example to understand how to make attestations to Kosl
 The following compliance template is expecting 4 attestations, each with its own `name`.
 
 ```yml
-# yaml-language-server: $schema=https://kosli.mintlify.app/schemas/flow-template.json
+# yaml-language-server: $schema=https://docs.kosli.com/schemas/flow-template.json
 version: 1
 trail:
   attestations:

--- a/getting_started/flows.md
+++ b/getting_started/flows.md
@@ -28,7 +28,7 @@ A Flow template is a YAML file following the syntax outlined in the [flow templa
 Here is an example:
 
 ```yml sw-delivery-template.yml
-# yaml-language-server: $schema=https://kosli.mintlify.app/schemas/flow-template.json
+# yaml-language-server: $schema=https://docs.kosli.com/schemas/flow-template.json
 version: 1
 trail:
   attestations:

--- a/getting_started/policies.md
+++ b/getting_started/policies.md
@@ -20,7 +20,7 @@ You can create a policy via CLI or via the API. Here is a basic policy that requ
 attestations:
 
 ```yaml prod-policy.yaml
-_schema: https://kosli.mintlify.app/schemas/policy/v1
+_schema: https://docs.kosli.com/schemas/policy/v1
 artifacts: # the rules apply to artifacts in an environment snapshot
   provenance:
     required: true # all artifacts must have provenance
@@ -92,7 +92,7 @@ artifacts:
 You can add exceptions to policy rules using [policy expressions](/policy-reference/environment_policy#policy-expressions).
 
 ```yaml
-_schema: https://kosli.mintlify.app/schemas/policy/v1
+_schema: https://docs.kosli.com/schemas/policy/v1
 
 artifacts:
   provenance:

--- a/labs/lab-04-release-controls.mdx
+++ b/labs/lab-04-release-controls.mdx
@@ -36,7 +36,7 @@ See [Flow Templates](/template-reference/flow_template) for the full template sp
     Create a file named `flow-template.yaml` in the root of your repository:
 
     ```yaml
-    # yaml-language-server: $schema=https://kosli.mintlify.app/schemas/flow-template.json
+    # yaml-language-server: $schema=https://docs.kosli.com/schemas/flow-template.json
     version: 1
     trail:
       artifacts:

--- a/labs/lab-05-runtime-controls.mdx
+++ b/labs/lab-05-runtime-controls.mdx
@@ -95,7 +95,7 @@ See [Environments](/getting_started/environments) for more.
     Create `.kosli-policy.yml` in the root of your repository:
 
     ```yaml
-    _schema: https://kosli.mintlify.app/schemas/policy/v1
+    _schema: https://docs.kosli.com/schemas/policy/v1
 
     artifacts:
       provenance:

--- a/policy-reference/environment_policy.mdx
+++ b/policy-reference/environment_policy.mdx
@@ -8,11 +8,11 @@ An environment policy is a YAML file that declares compliance requirements for a
 ## Specification
 
 <ParamField path="_schema" type="string" required>
-  Version identifier and [JSON Schema](https://kosli.mintlify.app/schemas/policy/v1.json) URL for the policy format. The final path segment must match `/v{n}` where `n` is a supported major version. Currently only `v1` is supported.
+  Version identifier and [JSON Schema](https://docs.kosli.com/schemas/policy/v1.json) URL for the policy format. The final path segment must match `/v{n}` where `n` is a supported major version. Currently only `v1` is supported.
 
   ```yaml
-  # yaml-language-server: $schema=https://kosli.mintlify.app/schemas/policy/v1.json
-  _schema: https://kosli.mintlify.app/schemas/policy/v1
+  # yaml-language-server: $schema=https://docs.kosli.com/schemas/policy/v1.json
+  _schema: https://docs.kosli.com/schemas/policy/v1
   ```
 </ParamField>
 
@@ -157,8 +157,8 @@ Parentheses control precedence: `${{ flow.name == 'prod' and (flow.tags.team == 
 ## Example
 
 ```yaml
-# yaml-language-server: $schema=https://kosli.mintlify.app/schemas/policy/v1.json
-_schema: https://kosli.mintlify.app/schemas/policy/v1
+# yaml-language-server: $schema=https://docs.kosli.com/schemas/policy/v1.json
+_schema: https://docs.kosli.com/schemas/policy/v1
 
 artifacts:
   provenance:
@@ -181,11 +181,11 @@ artifacts:
 
 ## Editor validation
 
-The `_schema` URL resolves to a [JSON Schema](https://kosli.mintlify.app/schemas/policy/v1.json) for the environment policy format. To enable inline validation and autocomplete in VS Code (requires the [YAML extension](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-yaml)) and other schema-aware editors, add a `yaml-language-server` directive:
+The `_schema` URL resolves to a [JSON Schema](https://docs.kosli.com/schemas/policy/v1.json) for the environment policy format. To enable inline validation and autocomplete in VS Code (requires the [YAML extension](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-yaml)) and other schema-aware editors, add a `yaml-language-server` directive:
 
 ```yaml
-# yaml-language-server: $schema=https://kosli.mintlify.app/schemas/policy/v1.json
-_schema: https://kosli.mintlify.app/schemas/policy/v1
+# yaml-language-server: $schema=https://docs.kosli.com/schemas/policy/v1.json
+_schema: https://docs.kosli.com/schemas/policy/v1
 ```
 
 ## See also

--- a/schemas/flow-template.json
+++ b/schemas/flow-template.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://kosli.mintlify.app/schemas/flow-template.json",
+  "$id": "https://docs.kosli.com/schemas/flow-template.json",
   "title": "Kosli Flow Template",
   "description": "Schema for Kosli flow template YAML files used with `kosli create flow --template-file`.",
   "type": "object",

--- a/schemas/policy/v1.json
+++ b/schemas/policy/v1.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "https://kosli.mintlify.app/schemas/policy/v1",
+  "$id": "https://docs.kosli.com/schemas/policy/v1",
   "title": "Kosli Environment Policy",
   "description": "Schema for Kosli environment policy YAML files used with `kosli create policy`.",
   "type": "object",
@@ -10,7 +10,7 @@
     "_schema": {
       "type": "string",
       "format": "uri",
-      "description": "URL of this schema. The path must end with /v{n} where n is the major version (e.g. .../v1). Example: https://kosli.mintlify.app/schemas/policy/v1"
+      "description": "URL of this schema. The path must end with /v{n} where n is the major version (e.g. .../v1). Example: https://docs.kosli.com/schemas/policy/v1"
     },
     "artifacts": {
       "type": "object",

--- a/template-reference/flow_template.md
+++ b/template-reference/flow_template.md
@@ -60,7 +60,7 @@ A flow template defines what attestations are required for a trail and its artif
 Add the `$schema` comment to get editor validation and autocomplete:
 
 ```yaml
-# yaml-language-server: $schema=https://kosli.mintlify.app/schemas/flow-template.json
+# yaml-language-server: $schema=https://docs.kosli.com/schemas/flow-template.json
 version: 1
 trail:
   attestations:
@@ -99,8 +99,8 @@ Once the flow exists, start a trail with [`kosli begin trail`](/client_reference
 
 ## Editor validation
 
-A [JSON Schema](https://kosli.mintlify.app/schemas/flow-template.json) is available for the flow template format. Add the following comment to the top of your template file to enable inline validation and autocomplete in VS Code (requires the [YAML extension](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-yaml)) and other schema-aware editors:
+A [JSON Schema](https://docs.kosli.com/schemas/flow-template.json) is available for the flow template format. Add the following comment to the top of your template file to enable inline validation and autocomplete in VS Code (requires the [YAML extension](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-yaml)) and other schema-aware editors:
 
 ```yaml
-# yaml-language-server: $schema=https://kosli.mintlify.app/schemas/flow-template.json
+# yaml-language-server: $schema=https://docs.kosli.com/schemas/flow-template.json
 ```

--- a/terraform-reference/resources/policy.mdx
+++ b/terraform-reference/resources/policy.mdx
@@ -27,7 +27,7 @@ terraform {
 resource "kosli_policy" "minimal" {
   name = "basic-requirements"
   content = <<-YAML
-    _schema: https://kosli.mintlify.app/schemas/policy/v1
+    _schema: https://docs.kosli.com/schemas/policy/v1
     artifacts:
       provenance:
         required: true
@@ -39,7 +39,7 @@ resource "kosli_policy" "production" {
   name        = "prod-requirements"
   description = "Compliance requirements for production environments"
   content     = <<-YAML
-    _schema: https://kosli.mintlify.app/schemas/policy/v1
+    _schema: https://docs.kosli.com/schemas/policy/v1
     artifacts:
       provenance:
         required: true
@@ -67,7 +67,7 @@ terraform import kosli_policy.example prod-requirements
 
 ### Required
 
-- `content` (String) YAML content of the policy, conforming to the Kosli policy schema (`_schema: https://kosli.mintlify.app/schemas/policy/v1`). Supports heredoc syntax for multi-line YAML. Updating this value creates a new policy version.
+- `content` (String) YAML content of the policy, conforming to the Kosli policy schema (`_schema: https://docs.kosli.com/schemas/policy/v1`). Supports heredoc syntax for multi-line YAML. Updating this value creates a new policy version.
 - `name` (String) Name of the policy. Must be unique within the organization. Changing this will force recreation of the resource.
 
 ### Optional

--- a/tutorials/linking_trails_across_branches.md
+++ b/tutorials/linking_trails_across_branches.md
@@ -111,7 +111,7 @@ Use `kosli evaluate trail` on the main-branch build to evaluate the PR trail aga
     Add `pr-build-compliance` to your main flow's template so that missing evidence is flagged:
 
     ```yaml
-    # yaml-language-server: $schema=https://kosli.mintlify.app/schemas/flow-template.json
+    # yaml-language-server: $schema=https://docs.kosli.com/schemas/flow-template.json
     version: 1
     trail:
       attestations:


### PR DESCRIPTION
## Summary

- Replace all `kosli.mintlify.app` references with `docs.kosli.com` across 12 files
- Covers schemas, getting started guides, labs, templates, and README

Closes #72