### PR TITLE
fix: add redirect from /api_v2 to /api-reference

### DIFF
--- a/config/redirects.json
+++ b/config/redirects.json
@@ -50,5 +50,9 @@
   {
     "source": "/kosli_overview/what_is_kosli",
     "destination": "/understand_kosli/what_is_kosli"
+  },
+  {
+    "source": "/api_v2",
+    "destination": "/api-reference"
   }
 ]


### PR DESCRIPTION
## Summary

- Add redirect from `/api_v2` to `/api-reference` to fix 404 from the "API" link in the app.kosli.com footer