### PR TITLE
fix: require conventional commits in Mintlify workflow instructions

### DIFF
--- a/.mintlify/workflows/update-api-reference.md
+++ b/.mintlify/workflows/update-api-reference.md
@@ -32,4 +32,4 @@ If new endpoint tags (groups) are introduced, add corresponding entries to the A
 - If no API changes were introduced, do nothing.
 - Do not include private repository file paths, directory structures, code snippets, or any other internal implementation details in PR titles, descriptions, or commit messages. The PR body should only describe the user-facing change in terms of the API behavior.
 - Do not modify any files other than `api-reference/openapi.json` and `config/navigation.json`.
-- PR titles and commit messages **must** follow [Conventional Commits](https://www.conventionalcommits.org/) format: `type: short description` (lowercase, no period). Use `docs:` as the type. Example: `docs: update API reference for v2.5.0`.
+- PR titles and commit messages must follow the conventional commits format described in CLAUDE.md. Use `docs:` as the type.

--- a/.mintlify/workflows/update-api-reference.md
+++ b/.mintlify/workflows/update-api-reference.md
@@ -32,3 +32,4 @@ If new endpoint tags (groups) are introduced, add corresponding entries to the A
 - If no API changes were introduced, do nothing.
 - Do not include private repository file paths, directory structures, code snippets, or any other internal implementation details in PR titles, descriptions, or commit messages. The PR body should only describe the user-facing change in terms of the API behavior.
 - Do not modify any files other than `api-reference/openapi.json` and `config/navigation.json`.
+- PR titles and commit messages **must** follow [Conventional Commits](https://www.conventionalcommits.org/) format: `type: short description` (lowercase, no period). Use `docs:` as the type. Example: `docs: update API reference for v2.5.0`.

--- a/.mintlify/workflows/update-changelog.md
+++ b/.mintlify/workflows/update-changelog.md
@@ -41,4 +41,4 @@ If unsure about the structure, review recent changelog updates and follow that s
 
 Be polite and terse. The changelog must be skimmable and quick to read. Include relevant links to docs pages.
 
-PR titles and commit messages **must** follow [Conventional Commits](https://www.conventionalcommits.org/) format: `type: short description` (lowercase, no period). Use `docs:` as the type. Example: `docs: add changelog entry for CLI v2.5.0`.
+PR titles and commit messages must follow the conventional commits format described in CLAUDE.md. Use `docs:` as the type.

--- a/.mintlify/workflows/update-changelog.md
+++ b/.mintlify/workflows/update-changelog.md
@@ -40,3 +40,5 @@ For each change, describe what changed and what it means for users. Organize ent
 If unsure about the structure, review recent changelog updates and follow that style and format.
 
 Be polite and terse. The changelog must be skimmable and quick to read. Include relevant links to docs pages.
+
+PR titles and commit messages **must** follow [Conventional Commits](https://www.conventionalcommits.org/) format: `type: short description` (lowercase, no period). Use `docs:` as the type. Example: `docs: add changelog entry for CLI v2.5.0`.

--- a/.mintlify/workflows/update-terraform-reference.md
+++ b/.mintlify/workflows/update-terraform-reference.md
@@ -28,3 +28,5 @@ When creating or updating pages:
 - Include example usage, schema (required/optional/read-only), and import instructions where applicable.
 
 Do not modify changelog/index.mdx — that is handled by the "Update changelog" workflow.
+
+PR titles and commit messages **must** follow [Conventional Commits](https://www.conventionalcommits.org/) format: `type: short description` (lowercase, no period). Use `docs:` as the type. Example: `docs: update Terraform reference for v1.3.0`.

--- a/.mintlify/workflows/update-terraform-reference.md
+++ b/.mintlify/workflows/update-terraform-reference.md
@@ -29,4 +29,4 @@ When creating or updating pages:
 
 Do not modify changelog/index.mdx — that is handled by the "Update changelog" workflow.
 
-PR titles and commit messages **must** follow [Conventional Commits](https://www.conventionalcommits.org/) format: `type: short description` (lowercase, no period). Use `docs:` as the type. Example: `docs: update Terraform reference for v1.3.0`.
+PR titles and commit messages must follow the conventional commits format described in CLAUDE.md. Use `docs:` as the type.


### PR DESCRIPTION
## Summary

- Add conventional commit format requirement to all three Mintlify workflows (`update-api-reference`, `update-changelog`, `update-terraform-reference`)
- PRs opened by these workflows were failing the `pr-quality.yml` title validation check because the workflows had no instruction to use conventional commit format