### PR TITLE
docs: add data flags comparison to attestations page

### DIFF
--- a/getting_started/attestations.md
+++ b/getting_started/attestations.md
@@ -161,42 +161,46 @@ All `kosli attest` commands support flags for attaching additional data. These f
 
 | Flag | Available on | Purpose |
 |------|-------------|---------|
-| `--user-data` | All attest commands | Attach structured JSON metadata that is stored and visible alongside the attestation in the Kosli UI |
-| `--attachments` | All attest commands | Upload files or directories to the Evidence Vault as compressed archives for later download |
+| `--user-data` | All evidence attest commands | Attach structured JSON metadata that is stored and visible alongside the attestation in the Kosli UI |
+| `--attachments` | All evidence attest commands | Upload files or directories to the Evidence Vault as compressed archives for later download |
 | `--attestation-data` | `attest custom` only | Provide the JSON payload that the custom type's jq rules evaluate to determine compliance |
 
 ### When to use which
 
 Use **`--user-data`** when you want to store additional context — such as build metadata, environment
-variables, or tool versions — that should be visible and queryable in the attestation record.
+variables, or tool versions — that is visible alongside the attestation in the Kosli UI.
 
 ```shell
 kosli attest generic \
     --name security-scan \
-    --user-data scan-metadata.json \
-    ...
+    --flow backend-ci \
+    --trail $(git rev-parse HEAD) \
+    --user-data scan-metadata.json
 ```
 
 Use **`--attachments`** when you want to archive files for audit purposes — such as test reports,
-scan output, or policy files — in the Evidence Vault for later retrieval.
+scan output, or policy files — in the Evidence Vault for later retrieval. Provide multiple paths
+as a comma-separated list.
 
 ```shell
 kosli attest generic \
     --name security-scan \
-    --attachments scan-report.html,scan-config.yml \
-    ...
+    --flow backend-ci \
+    --trail $(git rev-parse HEAD) \
+    --attachments scan-report.html,scan-config.yml
 ```
 
 Use **`--attestation-data`** on `kosli attest custom` to provide the JSON data that the custom
 attestation type's jq expression evaluates. This is what determines the compliance status of the
-attestation.
+attestation. See the [Custom](#custom) attestation type below for details.
 
 ```shell
 kosli attest custom \
     --type coverage-metrics \
     --name unit-tests \
-    --attestation-data coverage-results.json \
-    ...
+    --flow backend-ci \
+    --trail $(git rev-parse HEAD) \
+    --attestation-data coverage-results.json
 ```
 
 <Tip>

--- a/getting_started/attestations.md
+++ b/getting_started/attestations.md
@@ -155,6 +155,56 @@ Along with attestations data, you can attach additional supporting evidence file
 For `JUnit` attestations (see below), Kosli automatically stores the JUnit XML results files in the Evidence Vault. You can disable this by setting `--upload-results=false`
 </Note>
 
+## Attaching data to attestations
+
+All `kosli attest` commands support flags for attaching additional data. These flags accept file paths but serve different purposes:
+
+| Flag | Available on | Purpose |
+|------|-------------|---------|
+| `--user-data` | All attest commands | Attach structured JSON metadata that is stored and visible alongside the attestation in the Kosli UI |
+| `--attachments` | All attest commands | Upload files or directories to the Evidence Vault as compressed archives for later download |
+| `--attestation-data` | `attest custom` only | Provide the JSON payload that the custom type's jq rules evaluate to determine compliance |
+
+### When to use which
+
+Use **`--user-data`** when you want to store additional context — such as build metadata, environment
+variables, or tool versions — that should be visible and queryable in the attestation record.
+
+```shell
+kosli attest generic \
+    --name security-scan \
+    --user-data scan-metadata.json \
+    ...
+```
+
+Use **`--attachments`** when you want to archive files for audit purposes — such as test reports,
+scan output, or policy files — in the Evidence Vault for later retrieval.
+
+```shell
+kosli attest generic \
+    --name security-scan \
+    --attachments scan-report.html,scan-config.yml \
+    ...
+```
+
+Use **`--attestation-data`** on `kosli attest custom` to provide the JSON data that the custom
+attestation type's jq expression evaluates. This is what determines the compliance status of the
+attestation.
+
+```shell
+kosli attest custom \
+    --type coverage-metrics \
+    --name unit-tests \
+    --attestation-data coverage-results.json \
+    ...
+```
+
+<Tip>
+These flags can be combined. For example, you can use `--attestation-data` for compliance evaluation,
+`--user-data` to store extra metadata, and `--attachments` to archive the full report — all on the
+same attestation.
+</Tip>
+
 ## Attestation types
 
 Currently, we support the following types of evidence:

--- a/getting_started/attestations.md
+++ b/getting_started/attestations.md
@@ -209,12 +209,6 @@ These flags can be combined. For example, you can use `--attestation-data` for c
 same attestation.
 </Tip>
 
-<Warning>
-The total request payload — including all data and attachments — is limited to **10 MB** per attestation.
-This applies to `--user-data`, `--attachments`, and `--attestation-data` combined. If you need to
-attach larger files, store them externally and use `--external-url` to link to them.
-</Warning>
-
 ## Attestation types
 
 Currently, we support the following types of evidence:

--- a/getting_started/attestations.md
+++ b/getting_started/attestations.md
@@ -209,6 +209,12 @@ These flags can be combined. For example, you can use `--attestation-data` for c
 same attestation.
 </Tip>
 
+<Warning>
+The total request payload — including all data and attachments — is limited to **10 MB** per attestation.
+This applies to `--user-data`, `--attachments`, and `--attestation-data` combined. If you need to
+attach larger files, store them externally and use `--external-url` to link to them.
+</Warning>
+
 ## Attestation types
 
 Currently, we support the following types of evidence:


### PR DESCRIPTION
## Summary

- Adds an "Attaching data to attestations" section to `getting_started/attestations.md` explaining the difference between `--user-data`, `--attachments`, and `--attestation-data`
- Includes a comparison table and usage examples for each flag
- Placed between the existing "Evidence Vault" and "Attestation types" sections

Closes #171