### PR TITLE
fix: add missing kosli evaluate input to CLI navigation

### DIFF
--- a/config/navigation.json
+++ b/config/navigation.json
@@ -300,6 +300,7 @@
             {
               "group": "kosli evaluate",
               "pages": [
+                "client_reference/kosli_evaluate_input",
                 "client_reference/kosli_evaluate_trail",
                 "client_reference/kosli_evaluate_trails"
               ]


### PR DESCRIPTION
## Summary

- Adds `client_reference/kosli_evaluate_input` to the `kosli evaluate` navigation group in `config/navigation.json`
- The page file already exists (generated from CLI v2.15.0) but was never added to navigation

Root cause: the `update-cli-nav.py` script silently fails because navigation moved from `docs.json` to `config/navigation.json` via `$ref` — tracked in #174.

Closes #175