### PR TITLE
feat: add termly cookie consent banner with cross-subdomain sync

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -36,6 +36,12 @@
   "metadata": {
     "timestamp": true
   },
+  "integrations": {
+    "cookies": {
+      "key": "kosli_consent",
+      "value": "accepted"
+    }
+  },
   "favicon": "/favicon-32x32.png",
   "redirects": {
     "$ref": "./config/redirects.json"

--- a/termly.js
+++ b/termly.js
@@ -15,14 +15,28 @@
     "youtube.com": "essential"
   };
 
+  function syncConsent(data) {
+    if (data.categories && data.categories.includes("analytics")) {
+      localStorage.setItem("kosli_consent", "accepted");
+    } else {
+      localStorage.removeItem("kosli_consent");
+    }
+  }
+
+  // Called when the Termly script finishes loading.
+  window.onTermlyLoaded = function () {
+    if (window.Termly && window.Termly.on) {
+      Termly.on("consent", syncConsent);
+    }
+  };
+
   function init() {
     if (!document.getElementById("kosli-termly-embed")) {
       const s = document.createElement("script");
       s.id = "kosli-termly-embed";
-      s.src = "https://app.termly.io/embed.min.js";
-      s.setAttribute("data-auto-block", "on");
-      s.setAttribute("data-website-uuid", "c98bfcd6-2f30-4f3c-b53c-d6dbd9b8c40c");
+      s.src = "https://app.termly.io/resource-blocker/c98bfcd6-2f30-4f3c-b53c-d6dbd9b8c40c?autoBlock=on";
       s.setAttribute("data-master-consents-origin", "https://www.kosli.com");
+      s.setAttribute("onload", "onTermlyLoaded()");
       document.head.appendChild(s);
     }
 
@@ -36,15 +50,6 @@
       (document.body || document.documentElement).appendChild(f);
     }
   }
-
-  window.addEventListener("termly.consent", function (e) {
-    const analytics = e && e.detail && e.detail.analytics;
-    if (analytics) {
-      localStorage.setItem("kosli_consent", "accepted");
-    } else {
-      localStorage.removeItem("kosli_consent");
-    }
-  });
 
   if (document.readyState === "loading") {
     document.addEventListener("DOMContentLoaded", init, { once: true });

--- a/termly.js
+++ b/termly.js
@@ -10,9 +10,7 @@
   window.__kosliTermlyLoaded = true;
 
   window.TERMLY_CUSTOM_BLOCKING_MAP = {
-    "kosli.com": "essential",
-    "unpkg.com": "essential",
-    "youtube.com": "essential"
+    "kosli.com": "essential"
   };
 
   function syncConsent(data) {

--- a/termly.js
+++ b/termly.js
@@ -1,0 +1,54 @@
+// Termly cookie consent banner + cross-subdomain consent sync from www.kosli.com.
+// Mintlify auto-includes any .js file at the content root on every page,
+// so this loads on every doc page on docs.kosli.com.
+//
+// Companion config: docs.json `integrations.cookies` gates Mintlify's own
+// telemetry on the `kosli_consent` localStorage flag we set below.
+
+(function () {
+  if (window.__kosliTermlyLoaded) return;
+  window.__kosliTermlyLoaded = true;
+
+  window.TERMLY_CUSTOM_BLOCKING_MAP = {
+    "kosli.com": "essential",
+    "unpkg.com": "essential",
+    "youtube.com": "essential"
+  };
+
+  function init() {
+    if (!document.getElementById("kosli-termly-embed")) {
+      const s = document.createElement("script");
+      s.id = "kosli-termly-embed";
+      s.src = "https://app.termly.io/embed.min.js";
+      s.setAttribute("data-auto-block", "on");
+      s.setAttribute("data-website-uuid", "c98bfcd6-2f30-4f3c-b53c-d6dbd9b8c40c");
+      s.setAttribute("data-master-consents-origin", "https://www.kosli.com");
+      document.head.appendChild(s);
+    }
+
+    if (!document.getElementById("kosli-consent-sync")) {
+      const f = document.createElement("iframe");
+      f.id = "kosli-consent-sync";
+      f.src = "https://www.kosli.com/consent-sync.html";
+      f.title = "consent sync";
+      f.setAttribute("aria-hidden", "true");
+      f.style.display = "none";
+      (document.body || document.documentElement).appendChild(f);
+    }
+  }
+
+  window.addEventListener("termly.consent", function (e) {
+    const analytics = e && e.detail && e.detail.analytics;
+    if (analytics) {
+      localStorage.setItem("kosli_consent", "accepted");
+    } else {
+      localStorage.removeItem("kosli_consent");
+    }
+  });
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", init, { once: true });
+  } else {
+    init();
+  }
+})();


### PR DESCRIPTION
## Summary

- Adds `termly.js` at the content root. Mintlify auto-includes any `.js` file there on every page, so this loads the Termly banner across all of `docs.kosli.com`.
- Adds an `integrations.cookies` block in `docs.json` pointing at the `kosli_consent` localStorage flag — Mintlify gates its own telemetry on this, so their analytics doesn't fire pre-consent (per https://www.mintlify.com/docs/integrations/privacy/overview#cookie-consent-and-disabling-telemetry).
- Termly embed uses the same `data-website-uuid` as `www.kosli.com` (single Termly property) plus `data-master-consents-origin="https://www.kosli.com"` to read consent from the parent.
- Hidden iframe → `https://www.kosli.com/consent-sync.html` provides Termly's documented cross-subdomain consent sharing, so users who already consented on the marketing site aren't re-prompted on docs.
- `TERMLY_CUSTOM_BLOCKING_MAP` includes `"kosli.com": "essential"` so Termly's auto-blocker doesn't sandbox the consent-sync iframe and break the handshake.
- SPA-execution guard (`window.__kosliTermlyLoaded`) prevents duplicate iframes on Mintlify client-side route changes.
- A `termly.consent` event listener mirrors Termly's consent state to the `kosli_consent` localStorage flag that Mintlify reads.

## Why

Termly currently runs only on `www.kosli.com`. Visitors landing directly on `docs.kosli.com` are never prompted, which is a GDPR/ePrivacy gap. Mintlify doesn't expose `<head>` injection, so this uses the documented `.js`-in-content-root path plus the privacy integration.

## Dependencies

**Land in this order:**

1. https://github.com/kosli-dev/www.kosli.com/pull/1787 — relaxes `frame-ancestors` / `X-Frame-Options` on `/consent-sync.html` so this iframe isn't blocked.
2. This PR.

Out-of-band setup (issue tracks): add `docs.kosli.com` to Termly Scan Settings, confirm cookie domain is `.kosli.com`.

Tracking issue: https://github.com/kosli-dev/server/issues/5551

## Known limitation (documented in tracking issue)

Mintlify content-dir JS executes after hydration, so `data-auto-block` only catches scripts that fire after Termly mounts. Mintlify's own telemetry is now gated by `integrations.cookies` so that's covered. Anything we embed in MDX that fires earlier (YouTube, Loom, etc.) is the residual risk — worth a network-tab audit before merge.

## Test plan

- [ ] Mintlify deploy preview builds without `docs.json` schema errors.
- [ ] Visit a deploy-preview page: Termly banner appears.
- [ ] Hidden iframe to `https://www.kosli.com/consent-sync.html` loads without CSP / X-Frame-Options errors in browser console (requires PR 1787 deployed first).
- [ ] Accept cookies on the docs preview → `localStorage.kosli_consent === "accepted"`.
- [ ] Reload docs preview after consenting on `www.kosli.com` → banner does not re-appear (cross-subdomain sync working).
- [ ] Network tab: confirm Mintlify telemetry endpoints are not called before consent.
- [ ] Navigate between pages: only one Termly script tag and one consent-sync iframe in the DOM (SPA guard working).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

closes #86