### PR TITLE
feat: add MixPanel integration

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -72,6 +72,11 @@
       "vscode"
     ]
   },
+  "integrations": {
+    "mixpanel": {
+      "projectToken": "bf8ac483215f65141ab7ad825b079662"
+    }
+  },
   "footer": {
     "$ref": "./config/footer.json"
   }


### PR DESCRIPTION
## Summary

- Adds MixPanel integration to `docs.json` with project token for docs analytics tracking

## Blocked

This PR should not be merged until #188 has been merged. The Termly cookie consent banner must be in place before enabling MixPanel analytics, so that user consent is collected before any tracking fires.

## Test plan

- [ ] Verify MixPanel events appear in the MixPanel dashboard after merging