### PR TITLE
fix: pass masterConsentsOrigin as URL param and merge duplicate integrations key

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -36,12 +36,6 @@
   "metadata": {
     "timestamp": true
   },
-  "integrations": {
-    "cookies": {
-      "key": "kosli_consent",
-      "value": "accepted"
-    }
-  },
   "favicon": "/favicon-32x32.png",
   "redirects": {
     "$ref": "./config/redirects.json"
@@ -79,6 +73,10 @@
     ]
   },
   "integrations": {
+    "cookies": {
+      "key": "kosli_consent",
+      "value": "accepted"
+    },
     "mixpanel": {
       "projectToken": "bf8ac483215f65141ab7ad825b079662"
     }

--- a/termly.js
+++ b/termly.js
@@ -32,8 +32,7 @@
     if (!document.getElementById("kosli-termly-embed")) {
       const s = document.createElement("script");
       s.id = "kosli-termly-embed";
-      s.src = "https://app.termly.io/resource-blocker/c98bfcd6-2f30-4f3c-b53c-d6dbd9b8c40c?autoBlock=on";
-      s.setAttribute("data-master-consents-origin", "https://www.kosli.com");
+      s.src = "https://app.termly.io/resource-blocker/c98bfcd6-2f30-4f3c-b53c-d6dbd9b8c40c?autoBlock=on&masterConsentsOrigin=https://www.kosli.com";
       s.setAttribute("onload", "onTermlyLoaded()");
       document.head.appendChild(s);
     }


### PR DESCRIPTION
## Summary

- **termly.js**: `masterConsentsOrigin` was set as a `data-` attribute instead of a URL query parameter, so Termly never read it and consent sync between www.kosli.com and docs.kosli.com did not work. Now passed as `&masterConsentsOrigin=https://www.kosli.com` on the script src URL per [Termly docs](https://support.termly.io/hc/en-us/articles/30710516322321).
- **docs.json**: Two duplicate `integrations` keys — the second (mixpanel) silently overwrote the first (cookies), dropping the cookie consent gating for Mintlify telemetry. Merged into a single key.

## Test plan

- [ ] Deploy to docs.kosli.com
- [ ] Accept cookies on www.kosli.com
- [ ] Open docs.kosli.com in a new tab — banner should NOT appear (consent synced)
- [ ] Open docs.kosli.com in incognito — banner SHOULD appear