### PR TITLE
fix: whitelist docs.kosli.com and mintlify.app in Termly blocking map

### DIFF
--- a/termly.js
+++ b/termly.js
@@ -10,7 +10,9 @@
   window.__kosliTermlyLoaded = true;
 
   window.TERMLY_CUSTOM_BLOCKING_MAP = {
-    "kosli.com": "essential"
+    "kosli.com": "essential",
+    "docs.kosli.com": "essential",
+    "mintlify.app": "essential"
   };
 
   function syncConsent(data) {


### PR DESCRIPTION
## Summary

- Adds `docs.kosli.com` and `mintlify.app` to `TERMLY_CUSTOM_BLOCKING_MAP` as essential
- Termly's auto-blocker was intercepting Mintlify's internal Next.js requests (RSC payload prefetches and JS chunk loads), causing `Failed to fetch RSC payload` and `ChunkLoadError` in the console

This is the same issue Mintlify documents for Osano's strict mode — the consent auto-blocker needs to know the site's own assets are essential.

## Test plan

- [ ] Deploy and check console — RSC payload and ChunkLoadError errors should be gone
- [ ] Cookie consent banner should still appear and function
- [ ] Consent sync from www.kosli.com should still work