### PR TITLE
docs: add missing Platform changelog and fix workflow for server repo

### DIFF
--- a/.mintlify/workflows/update-changelog.md
+++ b/.mintlify/workflows/update-changelog.md
@@ -14,13 +14,16 @@ notify:
 
 # Agent Instructions
 
-Check each repository (kosli-dev/cli, kosli-dev/terraform-provider-kosli, kosli-dev/server) for **new tags/releases** published since the last changelog entry for that product in changelog/index.mdx. Only document changes that are part of a tagged release — do not include unreleased work on `main`.
+Check each repository for **new tags** published since the last changelog entry for that product in changelog/index.mdx. Only document changes that are part of a tagged release — do not include unreleased work on `main`.
 
-For each new release tag found, write a changelog entry in changelog/index.mdx. If no new tags exist for a repository since its last changelog entry, skip it. If there are no new tags across any repository, do not open a PR.
+- **kosli-dev/cli** and **kosli-dev/terraform-provider-kosli** use semver GitHub Releases (e.g., `v2.17.5`, `v0.6.3`). Check the Releases list for new versions.
+- **kosli-dev/server** does **not** use GitHub Releases. It uses timestamp-based git tags (e.g., `release-2026-04-30-10-56-05`). You must check git **tags** (not Releases) and look at the commits between the last covered tag and the most recent tag to identify user-facing changes. Consolidate all server changes since the last Platform changelog entry into a single entry.
+
+For each new release found, write a changelog entry in changelog/index.mdx. If no new tags exist for a repository since its last changelog entry, skip it. If there are no new tags across any repository, do not open a PR.
 
 This workflow only updates changelog/index.mdx. Do not modify any other files.
 
-Label should be the date the workflow runs, like "March 16, 2026". Description should be the version number of the release, like "v0.3.0".
+Label should be the date the workflow runs, like "March 16, 2026". Description should be the version number of the release for semver repositories (e.g., "v0.3.0"). For kosli-dev/server, leave description empty (`""`) since it has no semver version.
 Tags should be the product(s) affected by the release:
 - kosli-dev/cli → `["CLI"]`
 - kosli-dev/terraform-provider-kosli → `["Terraform Provider"]`

--- a/changelog/index.mdx
+++ b/changelog/index.mdx
@@ -4,6 +4,32 @@ description: "Release notes for Kosli products."
 rss: true
 ---
 
+<Update label="May 4, 2026" description="" tags={["Platform"]}>
+
+## New features
+
+- **PATCH endpoint for environment updates** — a new `PATCH /environments/{org}/{env_name}` endpoint allows updating individual environment fields without replacing the entire resource. This fixes the issue where setting a description to an empty string was silently ignored, and enables proper support in the [Terraform provider](/terraform-reference/resources/environment).
+
+## Updates
+
+- **Significantly faster environment and snapshot pages** — eliminated thousands of redundant database queries during snapshot reporting and page rendering. For large environments (~800 artifacts), this removes approximately 5,600 unnecessary database round-trips per snapshot report. The environment events page, which previously took ~60 seconds to load for large environments, now loads normally.
+- **Infinite scroll on snapshot events tab** — the snapshot events tab now loads events incrementally via infinite scroll instead of all at once, improving responsiveness for environments with many events.
+- **Improved environment page search** — search and filter on the environment page now returns all matching artifacts in a single request with loading indicators, fixing broken behavior for large environments.
+- **Faster flow filter lookups** — environment pages that filter by flow now use a pre-materialized collection instead of scanning all artifacts, speeding up load times.
+- **Case-insensitive email lookups** — user and invitation email lookups no longer require exact case matching.
+- **Redirect preserved through login** — when a session expires, the original destination URL (e.g., an org invite page) is now preserved through the logout/login cycle.
+- **API documentation improvements** — the OpenAPI spec title is now "Kosli API", endpoints are sorted alphabetically, and server URLs are absolute for [API playground](/api-reference) compatibility.
+
+## Bug fixes
+
+- Fixed the flows filter incorrectly rejecting substring searches starting with hyphens, underscores, dots, or tildes.
+- Fixed the logical environment snapshot events tab raising an error, and the "Running" badge incorrectly counting exited artifacts.
+- Fixed a 500 error when listing API keys with legacy expiration timestamps.
+- Fixed unhandled exceptions during OAuth and SSO sign-in flows.
+- Security: upgraded xz/xz-libs packages to patch CVE-2026-34743.
+
+</Update>
+
 <Update label="May 4, 2026" description="v2.17.5" tags={["CLI"]}>
 
 ## Updates


### PR DESCRIPTION
## Summary

- Added the missing Platform changelog entry covering kosli-dev/server changes since April 20 (1 new feature, 7 updates, 5 bug fixes). The Mintlify changelog workflow silently skipped the server repo because it uses timestamp-based git tags (`release-2026-04-30-...`) instead of GitHub Releases.
- Updated `.mintlify/workflows/update-changelog.md` with explicit instructions for how each repo should be checked — Releases for CLI/TF Provider, git tags + commit diffs for server.

## Test plan

- [ ] Verify the new Platform entry renders correctly on the changelog page
- [ ] Confirm the workflow instructions are clear enough for Mintlify's agent to follow on next Monday's run