### PR TITLE
docs: update Helm chart reference to v2.2.1

### DIFF
--- a/helm/k8s_reporter.mdx
+++ b/helm/k8s_reporter.mdx
@@ -5,10 +5,10 @@ description: A Helm chart for installing the Kosli K8S reporter as a cronjob.
 
 # k8s-reporter
 
-![Version: 2.2.0](https://img.shields.io/badge/Version-2.2.0-informational?style=flat-square)
+![Version: 2.2.1](https://img.shields.io/badge/Version-2.2.1-informational?style=flat-square)
 
 <Info>
-This reference applies to **chart version 2.2.0**, which uses **CLI version v2.12.0** by default (`image.tag`).
+This reference applies to **chart version 2.2.1**. The default CLI version is the chart's `appVersion`.
 </Info>
 
 A Helm chart for installing the Kosli K8S reporter as a cronjob.
@@ -205,8 +205,8 @@ If you already run [cert-manager's trust-manager](https://cert-manager.io/docs/t
   The kosli reporter image repository.
 </ParamField>
 
-<ParamField path="image.tag" type="string" default="v2.12.0">
-  The kosli reporter image tag, overrides the image tag whose default is the chart appVersion.
+<ParamField path="image.tag" type="string" default="">
+  The kosli reporter image tag. Defaults to the chart `appVersion` when left empty.
 </ParamField>
 
 <ParamField path="image.pullPolicy" type="string" default="IfNotPresent">
@@ -232,7 +232,7 @@ If you already run [cert-manager's trust-manager](https://cert-manager.io/docs/t
 </ParamField>
 
 <ParamField path="reporterConfig.securityContext" type="object">
-  The security context for the reporter cronjob. Set to null or `{}` to disable security context entirely (not recommended). For OpenShift, you can omit `runAsUser` to let OpenShift assign the UID.
+  The security context for the reporter cronjob. Set to null or `{}` to disable security context entirely (not recommended). For OpenShift with SCC, explicitly set `runAsUser: null` to let OpenShift assign the UID from the allowed range. Simply omitting `runAsUser` from your values override will not work because Helm deep-merges with the chart defaults.
 
   Default:
   ```json
@@ -253,7 +253,7 @@ If you already run [cert-manager's trust-manager](https://cert-manager.io/docs/t
 </ParamField>
 
 <ParamField path="reporterConfig.securityContext.runAsUser" type="int" default="1000">
-  The user id to run as. Omit this field for OpenShift environments to allow automatic UID assignment.
+  The user id to run as. For OpenShift environments with SCC, set to `null` (`runAsUser: null`) to allow automatic UID assignment. Simply omitting this field will not work due to Helm's deep merge with chart defaults.
 </ParamField>
 
 ### Kosli API token

--- a/helm/k8s_reporter.mdx
+++ b/helm/k8s_reporter.mdx
@@ -5,8 +5,6 @@ description: A Helm chart for installing the Kosli K8S reporter as a cronjob.
 
 # k8s-reporter
 
-![Version: 2.2.1](https://img.shields.io/badge/Version-2.2.1-informational?style=flat-square)
-
 <Info>
 This reference applies to **chart version 2.2.1**. The default CLI version is the chart's `appVersion`.
 </Info>

--- a/helm/k8s_reporter.mdx
+++ b/helm/k8s_reporter.mdx
@@ -6,7 +6,7 @@ description: A Helm chart for installing the Kosli K8S reporter as a cronjob.
 # k8s-reporter
 
 <Info>
-This reference applies to **chart version 2.2.1**. The default CLI version is the chart's `appVersion`.
+This reference applies to **chart version 2.2.1** (CLI **v2.12.0** by default).
 </Info>
 
 A Helm chart for installing the Kosli K8S reporter as a cronjob.

--- a/helm/k8s_reporter.mdx
+++ b/helm/k8s_reporter.mdx
@@ -6,7 +6,7 @@ description: A Helm chart for installing the Kosli K8S reporter as a cronjob.
 # k8s-reporter
 
 <Info>
-This reference applies to **chart version 2.2.1** (CLI **v2.12.0** by default).
+This reference applies to **chart version 2.2.1**, which defaults to CLI **v2.12.0** via `appVersion`. Override with `image.tag`.
 </Info>
 
 A Helm chart for installing the Kosli K8S reporter as a cronjob.


### PR DESCRIPTION
## Summary

- Update the `.mdx` Helm chart reference to v2.2.1: version badge, info callout, and `image.tag` default (empty string, not hardcoded CLI version)
- Fix misleading OpenShift `securityContext` guidance — users must explicitly set `runAsUser: null`, not omit it (Helm deep-merges the default `1000` back in)

The auto-generated `.md` file remains unchanged. Upstream fix to make it Mintlify-compatible (remove `{.command}` fences, escape `<instance_name>`) is tracked in kosli-dev/cli#853.

## Test plan

- [ ] Verify `helm/k8s_reporter` renders correctly at http://localhost:3000/helm/k8s_reporter
- [ ] Check version badge shows 2.2.1