### PR TITLE
fix: remove outdated WIP warning from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,4 @@
 # Kosli Documentation
-
-> [!WARNING]
-> This documentation is still a work in progress and is not yet the official Kosli documentation.
-
 Source for [docs.kosli.com](https://docs.kosli.com), built with [Mintlify](https://mintlify.com).
 
 ## Development


### PR DESCRIPTION
## Summary
- Removes the "work in progress" warning from `README.md` since this repo is now the official Kosli documentation.

## Test plan
- [x] Verify the README renders correctly without the warning block.