### PR TITLE
fix: drop --mintlify flag from CLI docs generation workflow

### DIFF
--- a/.github/workflows/update-cli-docs.yml
+++ b/.github/workflows/update-cli-docs.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Generate Mintlify CLI docs
         run: |
           rm -f client_reference/kosli*.md
-          DOCS=true ./kosli docs --mintlify --dir client_reference/
+          DOCS=true ./kosli docs --dir client_reference/
           rm -f kosli
 
       - name: Set up Python


### PR DESCRIPTION
## Summary
- Removes the `--mintlify` flag from `kosli docs` in the reference docs workflow, since Mintlify becomes the default (and only) format after kosli-dev/cli#856.

Closes #203

## Blocked on
- kosli-dev/cli#856

## Test plan
- [ ] Merge kosli-dev/cli#856
- [ ] Trigger the `Update Reference Docs` workflow and verify CLI docs generate correctly without the flag.