### PR TITLE
feat: add PostHog analytics integration

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -79,6 +79,11 @@
     },
     "mixpanel": {
       "projectToken": "bf8ac483215f65141ab7ad825b079662"
+    },
+    "posthog": {
+      "apiKey": "phc_vKbCGJq5rzV4apArUzYDRwh6azCmgCPcLz8jTa9CgmGR",
+      "apiHost": "https://eu.posthog.com",
+      "sessionRecording": true
     }
   },
   "footer": {


### PR DESCRIPTION
## Summary
- Add PostHog analytics configuration to `docs.json` with EU-hosted endpoint and session recording enabled

## Test plan
- [ ] Verify PostHog events appear in the PostHog EU dashboard after deploying to a preview/staging environment
- [ ] Confirm session recordings are captured
- [ ] Verify existing MixPanel analytics still works alongside PostHog