### PR TITLE
docs: fix broken links

### DIFF
--- a/changelog/index.mdx
+++ b/changelog/index.mdx
@@ -18,7 +18,7 @@ rss: true
 - **Faster flow filter lookups** — environment pages that filter by flow now use a pre-materialized collection instead of scanning all artifacts, speeding up load times.
 - **Case-insensitive email lookups** — user and invitation email lookups no longer require exact case matching.
 - **Redirect preserved through login** — when a session expires, the original destination URL (e.g., an org invite page) is now preserved through the logout/login cycle.
-- **API documentation improvements** — the OpenAPI spec title is now "Kosli API", endpoints are sorted alphabetically, and server URLs are absolute for [API playground](/api-reference) compatibility.
+- **API documentation improvements** — the OpenAPI spec title is now "Kosli API", endpoints are sorted alphabetically, and server URLs are absolute for [API playground](/api-reference/actions/list-actions) compatibility.
 
 ## Bug fixes
 

--- a/config/redirects.json
+++ b/config/redirects.json
@@ -53,6 +53,6 @@
   },
   {
     "source": "/api_v2",
-    "destination": "/api-reference"
+    "destination": "/api-reference/actions/list-actions"
   }
 ]

--- a/integrations/slack.md
+++ b/integrations/slack.md
@@ -3,8 +3,7 @@ title: Slack
 description: Integrate Kosli with Slack using the Kosli Slack App to receive notifications and query your environments and artifacts directly from Slack.
 ---
 
-[Kosli Slack App](#kosli-slack-app) allows you to configure and receive notifications about changes in your environments
-and query Kosli about your environments and artifacts without leaving Slack window.
+Allows you to configure and receive notifications about changes in your environments and query Kosli about your environments and artifacts without leaving Slack window.
 
 <Steps>
   <Step title="Installation">

--- a/policy-reference/rego_policy.mdx
+++ b/policy-reference/rego_policy.mdx
@@ -274,7 +274,6 @@ violations contains msg if {
 
 ## Further reading
 
-- [Rego Style Guide](https://docs.styra.com/opa/rego-style-guide): naming, rule structure, and test conventions
-- [OPA Annotations](https://www.openpolicyagent.org/docs/latest/annotations/): including `entrypoint: true` for use with `opa build`
-- [OPA Best Practices](https://www.openpolicyagent.org/docs/latest/best-practices/)
+- [Rego Style Guide](https://www.openpolicyagent.org/docs/style-guide): naming, rule structure, and test conventions
+- [OPA Annotations](https://www.openpolicyagent.org/docs/policy-language#annotations): including `entrypoint: true` for use with `opa build`
 - [Tutorial: Evaluate trails with OPA policies](/tutorials/evaluate_trails_with_opa)

--- a/understand_kosli/what_is_kosli.md
+++ b/understand_kosli/what_is_kosli.md
@@ -9,7 +9,7 @@ Proving compliance in fast-moving software delivery is hard. Evidence is scatter
 
 Think of Kosli as a flight recorder for your software delivery lifecycle (SDLC). Like a flight recorder, Kosli does not control the plane. It records what happened so that after the fact you can reconstruct the sequence of events. The reason this matters in software is that incidents and audit questions are inevitable, but the ability to answer "what was running, how did it get there, and did it pass all required checks?" should not depend on someone's memory or a manual audit trail.
 
-You report events of interest (builds, test results, deployments, environment state) through the [CLI](/client_reference) or [API](/api-reference). Kosli stores each record as an immutable entry and evaluates it against the [controls](/understand_kosli/controls) defined in your policies. Change sources include build systems (CI pipelines), runtime environments (Kubernetes clusters, AWS ECS, Lambda), and business processes (onboarding, access management).
+You report events of interest (builds, test results, deployments, environment state) through the [CLI](/client_reference) or [API](/api-reference/actions/list-actions). Kosli stores each record as an immutable entry and evaluates it against the [controls](/understand_kosli/controls) defined in your policies. Change sources include build systems (CI pipelines), runtime environments (Kubernetes clusters, AWS ECS, Lambda), and business processes (onboarding, access management).
 
 <Frame>
   <img


### PR DESCRIPTION
## Summary
- Replaced broken OPA documentation links in `policy-reference/rego_policy.mdx` with current working URLs (style-guide, policy-language#annotations); dropped the "OPA Best Practices" bullet since that page no longer exists.
- Updated `/api-reference` links (in changelog, `what_is_kosli`, and the `/api_v2` redirect) to point at `/api-reference/actions/list-actions`, since the bare `/api-reference` path is not a valid destination.
- Removed a broken self-anchor link from `integrations/slack.md`.

## Test plan
- [x] `mint broken-links` reports no new broken links
- [x] Spot-check the OPA links resolve (style-guide, policy-language#annotations)
- [x] Spot-check `/api-reference/actions/list-actions` renders