### PR TITLE
ci: replace doc-reviewer plugin with local doc-review skill

### DIFF
--- a/.claude/skills/doc-review/SKILL.md
+++ b/.claude/skills/doc-review/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: doc-review
+description: Review documentation for quality, structure, and convention compliance. Use when the user wants to review docs, audit a page or section, check if content is clear, evaluate information architecture, or assess navigation. Do NOT use when the user wants to write or fix docs — use doc-write for that. Triggers on "review the docs", "audit this page", "is this getting-started page clear", "check the implementation guide section".
+---
+
+# Doc Review
+
+Evaluate technical docs against the Diátaxis framework, information-architecture best practices, and the project's CLAUDE.md.
+
+## Before reviewing
+
+1. **Read the project's CLAUDE.md** — it defines all site-specific conventions. Use it as your compliance checklist for writing style, components, link format, and frontmatter. If no CLAUDE.md exists, read 3-4 existing pages to infer conventions.
+2. **Read `docs.json`** to understand navigation structure.
+3. **Determine review scope** — single page, section, or full site. If unclear, ask the user which scope they want.
+
+## Page-level review
+
+1. **Diátaxis classification** — Identify the doc type (tutorial, how-to, reference, explanation). Does the content match? Common issue: tutorials mixed with reference material, or how-to guides that teach instead of solving.
+2. **Content quality** — Clear title? Accurate description? Complete for its doc type? Factually correct and current?
+3. **Structure** — Logical flow? Appropriate depth?
+4. **CLAUDE.md compliance** — Check the page against every rule and convention in the project's CLAUDE.md (frontmatter, components, links, writing style, don'ts).
+5. **Link validation** — Internal links resolve to existing files? (Use Glob/Grep to verify.)
+
+## Section-level review
+
+1. Read all pages in the section.
+2. Check navigation order — logical progression?
+3. Identify gaps — missing pages for common user tasks?
+4. Check Diátaxis balance — right mix of doc types?
+5. Verify cross-linking between related pages.
+6. Assess consistency in voice, structure, and components.
+
+## Site-level review
+
+1. Is the top-level navigation intuitive?
+2. Are tutorials, how-to guides, reference, and explanation clearly separated?
+3. Can new users find getting-started content quickly? Can experienced users find reference quickly?
+4. Structural issues: orphaned pages, deep nesting (>3 levels), overloaded sections, missing landing pages.
+
+## Output format
+
+Categorize findings as:
+- **Critical** — Broken functionality, factual errors, missing required content.
+- **Improvement** — Clarity issues, structural problems, missing best practices.
+- **Suggestion** — Nice-to-have enhancements.
+
+For each: **Location** (file:line or section), **Issue**, **Recommendation**.
+
+End with a summary: findings by category, overall assessment, top 3 priorities.

--- a/.claude/skills/doc-write/SKILL.md
+++ b/.claude/skills/doc-write/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: doc-write
+description: Create, write, or update documentation pages in a Mintlify-based docs site. Use when the user wants to write docs, create a new page, document a feature, add a guide or tutorial, or update existing documentation. Do NOT use for reviewing or auditing — use doc-review for that. Triggers on "write docs for X", "create a new page", "document this feature", "add a tutorial", "draft a how-to guide".
+---
+
+# Doc Write
+
+Author Mintlify docs pages following the Diátaxis framework and the project's CLAUDE.md.
+
+## Before writing
+
+1. **Read the project's CLAUDE.md** — it defines all site-specific conventions (components, writing style, link format, frontmatter, don'ts). Follow it exactly. If no CLAUDE.md exists, read 3-4 existing pages to infer conventions.
+2. **Read `docs.json`** to understand navigation structure.
+3. **Read 2-3 similar pages** to match the site's voice, structure, and component usage.
+4. **Search for existing content** using Grep and Glob — you may need to update rather than create.
+
+## Classify the doc type (Diátaxis)
+
+Every page must fit one of these four types. Classify before writing:
+
+| Type | Purpose | User need | Structure |
+|------|---------|-----------|-----------|
+| **Tutorial** | Learning-oriented | "Teach me X" | Step-by-step guided learning experience with expected outcomes |
+| **How-to guide** | Task-oriented | "How do I do X?" | Goal-focused steps, assumes knowledge, handles variations |
+| **Reference** | Information-oriented | "What is X?" | Complete, accurate, terse technical description |
+| **Explanation** | Understanding-oriented | "Why does X work this way?" | Context, background, trade-offs, alternatives |
+
+A common mistake is mixing tutorials with how-to guides — tutorials teach through doing, how-to guides solve specific problems. If the doc type is ambiguous, ask the user.
+
+## Writing process
+
+1. **Classify** the doc type and confirm with the user if uncertain.
+2. **Outline** the page structure based on the doc type.
+3. **Write** the MDX file following the project's CLAUDE.md conventions.
+4. **Place** the file in the correct directory and update `config/navigation.json` (or `docs.json` navigation, whichever the project uses).
+
+## Output
+
+Write files directly to disk using Write/Edit tools. Then report:
+- File path of the created/updated page.
+- Navigation entry added (path in `config/navigation.json` or `docs.json`).
+- Related pages that should cross-link to this one.

--- a/.github/workflows/doc-review.yml
+++ b/.github/workflows/doc-review.yml
@@ -48,11 +48,9 @@ jobs:
           anthropic_service_account_id: ${{ vars.ANTHROPIC_SERVICE_ACCOUNT_ID }}
           track_progress: true
           use_sticky_comment: true
-          # Install the kosli-plugins marketplace and the mintlify-docs plugin,
-          # which provides the `doc-reviewer` agent used below. Keeps the agent
-          # definition in one place (kosli-plugins) instead of duplicating it.
-          plugin_marketplaces: https://github.com/kosli-dev/kosli-plugins.git
-          plugins: mintlify-docs@kosli-plugins
+          # The `doc-review` skill is defined locally in
+          # `.claude/skills/doc-review/SKILL.md` and is picked up automatically
+          # from the checked-out repo.
           # --allowedTools is a whitelist - the agent can ONLY use these tools
           # plus the implicit Read/Grep/Glob set. Bash is scoped to the minimum
           # gh subcommands needed to read PR context and post comments.
@@ -64,9 +62,9 @@ jobs:
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.pull_request.number }}
 
-            You are reviewing a pull request to the Kosli docs site. Use the
-            `doc-reviewer` agent (from the mintlify-docs plugin) and the rules
-            in this repo's CLAUDE.md.
+            You are reviewing a pull request to the Kosli docs site. Follow
+            the `doc-review` skill (defined in `.claude/skills/doc-review/SKILL.md`)
+            and the rules in this repo's CLAUDE.md.
 
             Scope: only the docs files (.md, .mdx, config/navigation.json,
             docs.json) changed in this PR. Use `gh pr diff` to discover them.


### PR DESCRIPTION
## Summary
- Add `.claude/skills/doc-review/SKILL.md` and `.claude/skills/doc-write/SKILL.md`, ported from the `kosli-plugins/mintlify-docs` plugin agents (procedural content, so skills fit better than agents — no Task subagent indirection needed).
- Update `.github/workflows/doc-review.yml`:
  - Remove `plugin_marketplaces` / `plugins` inputs.
  - Point the prompt at the local `doc-review` skill.

## Why
The previous setup installed `kosli-dev/kosli-plugins` as a plugin marketplace inside the workflow. That repo is private and the workflow's `GITHUB_TOKEN` is scoped to this repo only, so the clone failed (see [run #26737836319](https://github.com/kosli-dev/docs/actions/runs/26737836319/job/78794679494)). Bringing the agent in-tree as a skill removes the auth surface entirely. Skills under `.claude/` are restored from `main` by the action automatically.

## Test plan
- [ ] Merge.
- [ ] Push an empty commit on `test-doc-review` to re-trigger PR #246's workflow.
- [ ] Confirm the doc-review workflow succeeds (WIF still configured, no marketplace clone) and the sticky comment flags the seeded violations in `tutorials/zz_doc_review_sandbox.mdx`.