### PR TITLE
docs: enforce american spelling and fix british variants

### DIFF
--- a/.vale.ini
+++ b/.vale.ini
@@ -1,5 +1,5 @@
 StylesPath = styles
 Vocab = Mintlify
 
-[*.md]
+[*.{md,mdx}]
 BasedOnStyles = Kosli

--- a/.vale.ini
+++ b/.vale.ini
@@ -1,2 +1,5 @@
 StylesPath = styles
 Vocab = Mintlify
+
+[*.md]
+BasedOnStyles = Kosli

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,6 +86,7 @@ description: One sentence describing the page purpose.
 - Use active voice and imperative mood for instructions ("Run `kosli attest`", not "You should run").
 - Refer to the product as **Kosli** — not "the Kosli platform" or "KOSLI".
 - Use "audit trail" not "audit log"; "attest" not "certify".
+- Use American spelling (organization, behavior, color), not British. Enforced by Vale via `styles/Kosli/AmericanSpelling.yml`.
 - Sentence case for all headings.
 
 ## Don'ts

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Other useful commands:
 
 ```bash
 mint broken-links   # Validate all internal links
-mint a11y           # Check colour contrast and accessibility
+mint a11y           # Check color contrast and accessibility
 mint update         # Update the mint CLI tool
 ```
 

--- a/changelog/index.mdx
+++ b/changelog/index.mdx
@@ -8,7 +8,7 @@ rss: true
 
 ## New features
 
-- **Default organisation on user profile** — pick a default organisation from a dropdown on your [profile settings page](https://app.kosli.com/settings/profile) so the Kosli app opens to it on sign-in.
+- **Default organization on user profile** — pick a default organization from a dropdown on your [profile settings page](https://app.kosli.com/settings/profile) so the Kosli app opens to it on sign-in.
 
 ## Updates
 
@@ -261,7 +261,7 @@ rss: true
 
 ## New features
 
-- **`--assert` / `--no-assert` for evaluate commands** — `kosli evaluate trail`, `kosli evaluate trails`, and `kosli evaluate input` now accept a mutually-exclusive `--assert` / `--no-assert` flag pair. Pass `--no-assert` to use these commands as a policy decision point: the verdict is printed and the command exits 0, leaving any assertion to a downstream step. Default behaviour is unchanged — a policy deny still exits non-zero. These commands are now marked `[BETA]`. See the [evaluate trail](/client_reference/kosli_evaluate_trail), [evaluate trails](/client_reference/kosli_evaluate_trails), and [evaluate input](/client_reference/kosli_evaluate_input) references.
+- **`--assert` / `--no-assert` for evaluate commands** — `kosli evaluate trail`, `kosli evaluate trails`, and `kosli evaluate input` now accept a mutually-exclusive `--assert` / `--no-assert` flag pair. Pass `--no-assert` to use these commands as a policy decision point: the verdict is printed and the command exits 0, leaving any assertion to a downstream step. Default behavior is unchanged — a policy deny still exits non-zero. These commands are now marked `[BETA]`. See the [evaluate trail](/client_reference/kosli_evaluate_trail), [evaluate trails](/client_reference/kosli_evaluate_trails), and [evaluate input](/client_reference/kosli_evaluate_input) references.
 
 ## Updates
 

--- a/styles/Kosli/AmericanSpelling.yml
+++ b/styles/Kosli/AmericanSpelling.yml
@@ -1,0 +1,17 @@
+extends: substitution
+message: "Use '%s' instead of '%s'."
+ignorecase: true
+level: error
+swap:
+  organisation: organization
+  organisations: organizations
+  organise: organize
+  organised: organized
+  organising: organizing
+  behaviour: behavior
+  behaviours: behaviors
+  colour: color
+  colours: colors
+  standardise: standardize
+  standardised: standardized
+  standardising: standardizing

--- a/tutorials/cli_and_http_proxy.md
+++ b/tutorials/cli_and_http_proxy.md
@@ -155,4 +155,4 @@ These two connections must be configured independently.
 
 ## What you've accomplished
 
-You have set up Tinyproxy as an HTTP proxy and configured the Kosli CLI to route all traffic through it. This pattern works with any HTTP proxy — replace `http://localhost:8888` with your organisation's proxy URL and run `kosli config --http-proxy=<your-proxy-url>` to apply it globally.
+You have set up Tinyproxy as an HTTP proxy and configured the Kosli CLI to route all traffic through it. This pattern works with any HTTP proxy — replace `http://localhost:8888` with your organization's proxy URL and run `kosli config --http-proxy=<your-proxy-url>` to apply it globally.

--- a/tutorials/custom-attestation-ctrf.md
+++ b/tutorials/custom-attestation-ctrf.md
@@ -3,7 +3,7 @@ title: "Creating custom CTRF attestation type"
 description: "In this tutorial, we will create a custom attestation type with schema and evaluation for Common Test Report Format"
 ---
 
-In this tutorial, we will create a <Tooltip tip="A user-defined attestation type in Kosli that validates reported data against a JSON schema and evaluates it against a jq compliance rule.">custom attestation type</Tooltip> for <Tooltip tip="Common Test Report Format — a standardised JSON schema for test execution reports that works across testing frameworks such as Jest, Pytest, and Mocha." cta="Learn more" href="https://ctrf.io/">CTRF</Tooltip>.
+In this tutorial, we will create a <Tooltip tip="A user-defined attestation type in Kosli that validates reported data against a JSON schema and evaluates it against a jq compliance rule.">custom attestation type</Tooltip> for <Tooltip tip="Common Test Report Format — a standardized JSON schema for test execution reports that works across testing frameworks such as Jest, Pytest, and Mocha." cta="Learn more" href="https://ctrf.io/">CTRF</Tooltip>.
 By the end, you will have a reusable `ctrf` attestation type in Kosli that validates test reports and enforces a zero-failures compliance rule.
 
 ## Prerequisites
@@ -56,7 +56,7 @@ Kosli will validate `ctrf-report.json` against the schema and evaluate the jq ru
 
 ## What you've accomplished
 
-You have created a reusable `ctrf` custom attestation type and used it to report a test result to Kosli. Any team in your organisation can now use this same type to uniformly enforce a zero-failures quality gate across all projects, regardless of which testing framework they use.
+You have created a reusable `ctrf` custom attestation type and used it to report a test result to Kosli. Any team in your organization can now use this same type to uniformly enforce a zero-failures quality gate across all projects, regardless of which testing framework they use.
 
 From here you can:
 * Read the [`kosli create attestation-type`](/client_reference/kosli_create_attestation-type) reference for all available options

--- a/tutorials/evaluate_trails_with_opa.mdx
+++ b/tutorials/evaluate_trails_with_opa.mdx
@@ -90,7 +90,7 @@ With the safe pattern, if `pull_requests` is undefined, `every pr in ...` fails 
 `violations` explains why a policy was denied -- it does not decide whether it was denied. When a `violations` rule body encounters an undefined reference, it silently produces no message. This is the safe failure mode: you lose a diagnostic, not a compliance check.
 
 <Info>
-See the [Rego Policy reference](/policy-reference/rego_policy) for the full policy contract, input data shape, and exit code behaviour.
+See the [Rego Policy reference](/policy-reference/rego_policy) for the full policy contract, input data shape, and exit code behavior.
 </Info>
 
 </Step>
@@ -250,7 +250,7 @@ violations contains msg if {
 
 **Why the aliases at the top matter**
 
-`max_high := data.params.max_high` is not just shorthand. In the compliance path, `result.high_count <= max_high` is a positive bound check. If `max_high` is absent from the params file, this condition is undefined, `artifact_within_threshold` fails to fire, and `allow` stays `false`. That is the correct fail-safe behaviour.
+`max_high := data.params.max_high` is not just shorthand. In the compliance path, `result.high_count <= max_high` is a positive bound check. If `max_high` is absent from the params file, this condition is undefined, `artifact_within_threshold` fails to fire, and `allow` stays `false`. That is the correct fail-safe behavior.
 
 Compare this to a policy that drives `allow` through the absence of violations:
 

--- a/tutorials/following_a_git_commit_to_runtime_environments.md
+++ b/tutorials/following_a_git_commit_to_runtime_environments.md
@@ -20,7 +20,7 @@ The commit we follow fixed a misconfiguration: `runner` should run with three re
 
 ## Setup
 
-Set your environment variables to use the public `cyber-dojo` Kosli organisation:
+Set your environment variables to use the public `cyber-dojo` Kosli organization:
 
 ```shell
 export KOSLI_ORG=cyber-dojo

--- a/tutorials/organizing_with_spaces.mdx
+++ b/tutorials/organizing_with_spaces.mdx
@@ -5,7 +5,7 @@ description: Learn how to use Kosli Spaces to hierarchically organize your Flows
 
 ## Introduction
 
-Spaces addresses a scaling challenge facing large organisations as they attempt to fully automate software delivery governance. Ingesting large amounts of data from hundreds of sources — CI/CD pipelines, security scanners, test frameworks, deployment tools — means that it becomes increasingly difficult for different stakeholders to access the information they need.
+Spaces addresses a scaling challenge facing large organizations as they attempt to fully automate software delivery governance. Ingesting large amounts of data from hundreds of sources — CI/CD pipelines, security scanners, test frameworks, deployment tools — means that it becomes increasingly difficult for different stakeholders to access the information they need.
 
 Kosli Spaces allows users to:
 

--- a/tutorials/organizing_with_spaces.mdx
+++ b/tutorials/organizing_with_spaces.mdx
@@ -5,7 +5,7 @@ description: Learn how to use Kosli Spaces to hierarchically organize your Flows
 
 ## Introduction
 
-Spaces addresses a scaling challenge facing large organizations as they attempt to fully automate software delivery governance. Ingesting large amounts of data from hundreds of sources — CI/CD pipelines, security scanners, test frameworks, deployment tools — means that it becomes increasingly difficult for different stakeholders to access the information they need.
+Spaces addresses a scaling challenge facing large organisations as they attempt to fully automate software delivery governance. Ingesting large amounts of data from hundreds of sources — CI/CD pipelines, security scanners, test frameworks, deployment tools — means that it becomes increasingly difficult for different stakeholders to access the information they need.
 
 Kosli Spaces allows users to:
 

--- a/tutorials/organizing_with_spaces.mdx
+++ b/tutorials/organizing_with_spaces.mdx
@@ -44,7 +44,7 @@ Acme Bank
 
 In this structure:
 
-- **Acme Bank** is the organisation, also referred to as the "root space"
+- **Acme Bank** is the organization, also referred to as the "root space"
 - **Investment Banking** and **Technology Services** are major divisions represented by Spaces
 - Each division contains business units (Trading Systems, Platform Engineering), also represented by nested spaces
 - **Trade Execution Platform** and **DevOps** are a project and a team, also nested spaces within the business units

--- a/tutorials/report_cloud_run_envs.md
+++ b/tutorials/report_cloud_run_envs.md
@@ -131,7 +131,7 @@ gcloud run jobs deploy kosli-reporter \
 ```
 
 <Tip>
-Pin the CLI image to a specific version (for example `ghcr.io/kosli-dev/cli:v2.18.0`) so the reporter behaviour does not change unexpectedly when a new release is published.
+Pin the CLI image to a specific version (for example `ghcr.io/kosli-dev/cli:v2.18.0`) so the reporter behavior does not change unexpectedly when a new release is published.
 </Tip>
 
 <Note>

--- a/tutorials/tracing_a_production_incident_back_to_git_commits.md
+++ b/tutorials/tracing_a_production_incident_back_to_git_commits.md
@@ -3,7 +3,7 @@ title: Tracing a production incident to its git commit
 description: "Learn how to use Kosli to trace a production 500 error in cyber-dojo back to the specific git commit that caused it — without any access to the production environment."
 ---
 
-By the end of this tutorial, you will have traced a production incident from a 500 error all the way back to the git commit that caused it, using only Kosli CLI queries against the public cyber-dojo organisation.
+By the end of this tutorial, you will have traced a production incident from a 500 error all the way back to the git commit that caused it, using only Kosli CLI queries against the public cyber-dojo organization.
 
 <Frame><img src="/images/cyber-dojo-prod-500-large.png" alt="Prod cyber-dojo is down with a 500" /></Frame>
 
@@ -16,7 +16,7 @@ By the end of this tutorial, you will have traced a production incident from a 5
 
 ## Setup
 
-The `cyber-dojo` Kosli organisation is public, so any authenticated user can read its data:
+The `cyber-dojo` Kosli organization is public, so any authenticated user can read its data:
 
 ```shell
 export KOSLI_ORG=cyber-dojo

--- a/understand_kosli/glossary.md
+++ b/understand_kosli/glossary.md
@@ -51,7 +51,7 @@ The compliance definition for a Flow. It specifies the artifacts and attestation
 
 ### Organization
 
-The account that owns Kosli resources (Flows, Environments, Policies). Most teams work within a shared organisation that maps to their company. Members are invited with specific roles that control access.
+The account that owns Kosli resources (Flows, Environments, Policies). Most teams work within a shared organization that maps to their company. Members are invited with specific roles that control access.
 
 ### Risk
 

--- a/understand_kosli/glossary.md
+++ b/understand_kosli/glossary.md
@@ -51,7 +51,7 @@ The compliance definition for a Flow. It specifies the artifacts and attestation
 
 ### Organization
 
-The account that owns Kosli resources (Flows, Environments, Policies). Most teams work within a shared organization that maps to their company. Members are invited with specific roles that control access.
+The account that owns Kosli resources (Flows, Environments, Policies). Most teams work within a shared organisation that maps to their company. Members are invited with specific roles that control access.
 
 ### Risk
 


### PR DESCRIPTION
## Summary

- Replace british spellings (organisation, behaviour, colour, standardised) with american equivalents across the published docs.
- Add a Vale `substitution` rule at `styles/Kosli/AmericanSpelling.yml` that flags the british variants currently appearing in the docs, wired into `.vale.ini` for `*.md` files.
- Note the convention in `CLAUDE.md` under Writing style, pointing to the Vale rule.

## Notes

- Kept the rule as an explicit word list rather than regex for readability; can compress to regex (`organis(e|ed|ing)` etc.) later if the list grows.
- Scope intentionally limited to british variants that actually appear in the docs today, not a comprehensive british→american dictionary.
- MDX files are not yet covered by local `vale .` runs (requires `mdx2vast`). Mintlify's Vale add-on can pick them up server-side if enabled.

## Test plan

- [x] `vale --glob='!{.claudemd-eval,docs}/**' .` reports 0 errors across published `.md` files.
- [x] Confirm `mint dev` still renders the edited tutorial and changelog pages without surprises.