### PR TITLE
docs: add page for setting default organization

### DIFF
--- a/administration/managing_organizations.md
+++ b/administration/managing_organizations.md
@@ -1,0 +1,24 @@
+---
+title: Managing Organizations
+description: Manage your Kosli organization preferences, including which organization the app opens to when you sign in.
+---
+
+If you belong to more than one Kosli organization, you can pick a default. The Kosli app will open to that organization each time you sign in.
+
+## Set your default organization
+
+<Steps>
+  <Step title="Open your profile settings">
+    Go to your profile settings page:
+
+    - EU: [app.kosli.com/settings/profile](https://app.kosli.com/settings/profile)
+    - US: [app.us.kosli.com/settings/profile](https://app.us.kosli.com/settings/profile)
+  </Step>
+  <Step title="Choose a default organization">
+    Under **Default organization**, select the organization you want to use as your default.
+  </Step>
+</Steps>
+
+The change takes effect on your next sign-in. You can still switch between organizations from the organization picker at any time.
+
+You can also set your default organization via the [API](/api-reference/user/set-default-organization).

--- a/config/navigation.json
+++ b/config/navigation.json
@@ -35,6 +35,7 @@
           "group": "Administration",
           "icon": "cog",
           "pages": [
+            "administration/managing_organizations",
             {
               "group": "Managing Users",
               "pages": [


### PR DESCRIPTION
## Summary

- Adds `administration/managing_organizations.md` documenting how a user sets their default Kosli organization from the profile settings page.
- Wires the page into `config/navigation.json` under Administration.
- EU and US instance URLs are presented as a labelled bullet list inside the first Step.

## Notes

- Pairs with the "Default organisation on user profile" platform release entry in the changelog.
- Page placement under Administration is provisional; if more account-scoped settings pages appear, a dedicated "Account" top-level category would be a better long-term home.