### PR TITLE
docs: clarify k8s multi-reporter impact on snapshots

### DIFF
--- a/tutorials/report_k8s_envs.md
+++ b/tutorials/report_k8s_envs.md
@@ -172,10 +172,10 @@ If you are considering running more than one reporter against the same cluster, 
 
 | Scenario | Works? | Explanation |
 | :--- | :---: | :--- |
-| Two orgs, separate environments, overlapping namespaces | ✅ | Different environments → independent snapshots. |
-| One org, two environments, overlapping namespaces | ✅ | Same as above. |
-| One org, **same environment**, two reporters with overlapping namespaces | ❌ | Snapshots toggle between each reporter's view. No data is deleted, but diffs between consecutive snapshots become meaningless. |
-| One org, same environment, two reporters with **disjoint** namespaces | ❌ | Each snapshot only reflects one reporter's namespaces, so diffs compare unrelated scopes. The reporter must be the sole source for the environment. |
+| Two orgs, separate environments, overlapping namespaces | Yes | Different environments → independent snapshots. |
+| One org, two environments, overlapping namespaces | Yes | Same as above. |
+| One org, **same environment**, two reporters with overlapping namespaces | No | Snapshots toggle between each reporter's view. No data is deleted, but diffs between consecutive snapshots become meaningless. |
+| One org, same environment, two reporters with **disjoint** namespaces | No | Each snapshot only reflects one reporter's namespaces, so diffs compare unrelated scopes. |
 
 <Warning>
 A single Kosli environment must have exactly one reporter feeding it. Snapshots are never overwritten or deleted, but if two reporters take turns updating the same environment:

--- a/tutorials/report_k8s_envs.md
+++ b/tutorials/report_k8s_envs.md
@@ -170,7 +170,7 @@ kosli snapshot k8s k8s-tutorial \
 
 If you are considering running more than one reporter against the same cluster, the table below summarizes which setups produce meaningful snapshots and which don't.
 
-| Scenario | Works? | Explanation |
+| Scenario | Supported | Explanation |
 | :--- | :---: | :--- |
 | Two orgs, separate environments, overlapping namespaces | Yes | Different environments → independent snapshots. |
 | One org, two environments, overlapping namespaces | Yes | Same as above. |

--- a/tutorials/report_k8s_envs.md
+++ b/tutorials/report_k8s_envs.md
@@ -177,7 +177,12 @@ If you are considering running more than one reporter against the same cluster, 
 | One org, **same environment**, two reporters with overlapping namespaces | ❌ | Snapshots toggle between each reporter's view. No data is deleted, but diffs between consecutive snapshots become meaningless. |
 | One org, same environment, two reporters with **disjoint** namespaces | ❌ | Each snapshot only reflects one reporter's namespaces, so diffs compare unrelated scopes. The reporter must be the sole source for the environment. |
 
-The rule of thumb: a single Kosli environment must have exactly one reporter feeding it. Snapshots are never overwritten or deleted, but if two reporters take turns updating the same environment, the diffs between snapshots compare unrelated views of the cluster and the environment history will show artifacts continuously stopping and starting as each report toggles which namespaces are visible.
+<Warning>
+A single Kosli environment must have exactly one reporter feeding it. Snapshots are never overwritten or deleted, but if two reporters take turns updating the same environment:
+
+- Diffs between consecutive snapshots compare unrelated views of the cluster.
+- The environment history shows artifacts continuously stopping and starting as each report toggles which namespaces are visible.
+</Warning>
 
 ## What you've accomplished
 

--- a/tutorials/report_k8s_envs.md
+++ b/tutorials/report_k8s_envs.md
@@ -168,16 +168,16 @@ kosli snapshot k8s k8s-tutorial \
 
 ## Running multiple reporters
 
-If you are considering running more than one reporter against the same cluster, the table below summarizes which setups are safe and which will cause data loss.
+If you are considering running more than one reporter against the same cluster, the table below summarizes which setups produce meaningful snapshots and which don't.
 
-| Scenario | Safe? |
-| --- | --- |
-| Two orgs, separate environments, overlapping namespaces | **Safe.** Different environments → separate snapshots. |
-| One org, two environments, overlapping namespaces | **Safe.** Same as above. |
-| One org, **same environment**, two reporters with overlapping namespaces | **Broken.** Snapshots toggle back and forth. Data is lost on each report. |
-| One org, same environment, two reporters with **disjoint** namespaces | **Still broken.** Each report wipes the namespaces the other reporter owns. The reporter must be the sole source for the environment. |
+| Scenario | Works? | Explanation |
+| :--- | :---: | :--- |
+| Two orgs, separate environments, overlapping namespaces | ✅ | Different environments → independent snapshots. |
+| One org, two environments, overlapping namespaces | ✅ | Same as above. |
+| One org, **same environment**, two reporters with overlapping namespaces | ❌ | Snapshots toggle between each reporter's view. No data is deleted, but diffs between consecutive snapshots become meaningless. |
+| One org, same environment, two reporters with **disjoint** namespaces | ❌ | Each snapshot only reflects one reporter's namespaces, so diffs compare unrelated scopes. The reporter must be the sole source for the environment. |
 
-The rule of thumb: a single Kosli environment must have exactly one reporter feeding it.
+The rule of thumb: a single Kosli environment must have exactly one reporter feeding it. Snapshots are never overwritten or deleted, but if two reporters take turns updating the same environment, the diffs between snapshots compare unrelated views of the cluster and the environment history will show artifacts continuously stopping and starting as each report toggles which namespaces are visible.
 
 ## What you've accomplished
 

--- a/tutorials/report_k8s_envs.md
+++ b/tutorials/report_k8s_envs.md
@@ -180,8 +180,8 @@ If you are considering running more than one reporter against the same cluster, 
 <Warning>
 A single Kosli environment must have exactly one reporter feeding it. Snapshots are never overwritten or deleted, but if two reporters take turns updating the same environment:
 
-- Diffs between consecutive snapshots compare unrelated views of the cluster.
-- The environment history shows artifacts continuously stopping and starting as each report toggles which namespaces are visible.
+* Diffs between consecutive snapshots compare unrelated views of the cluster.
+* The environment history shows artifacts continuously stopping and starting as each report toggles which namespaces are visible.
 </Warning>
 
 ## What you've accomplished


### PR DESCRIPTION
## Summary
- Reword the "Running multiple reporters" table so the Works? column is a single emoji and the explanation moves to its own column
- Correct the description of what happens with conflicting reporters: snapshots are not deleted; diffs between them just compare unrelated scopes
- Note that the environment history will show artifacts continuously stopping and starting as reporters toggle

## Test plan
- [x] `mint dev` and visually verify the table renders with three columns
- [x] Confirm no broken links via `mint broken-links`