### PR TITLE
chore: disable mixpanel telemetry integration

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -77,9 +77,6 @@
       "key": "kosli_consent",
       "value": "accepted"
     },
-    "mixpanel": {
-      "projectToken": "bf8ac483215f65141ab7ad825b079662"
-    },
     "posthog": {
       "apiKey": "phc_vKbCGJq5rzV4apArUzYDRwh6azCmgCPcLz8jTa9CgmGR",
       "apiHost": "https://eu.posthog.com",


### PR DESCRIPTION
## What

Removes the `mixpanel` integration block from `docs.json`, disabling Mixpanel telemetry on the docs site.

## Why

We no longer want to send analytics telemetry to Mixpanel.

## Impact

- Mintlify will no longer load the Mixpanel SDK or send events to it.
- PostHog analytics and cookie-consent integrations are unchanged.