### PR TITLE
fix(ci): allow mintlify and github-actions bots to trigger doc review

### DIFF
--- a/.github/workflows/doc-review.yml
+++ b/.github/workflows/doc-review.yml
@@ -43,6 +43,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         with:
+          allowed_bots: "mintlify,github-actions"
           anthropic_federation_rule_id: ${{ vars.ANTHROPIC_FEDERATION_RULE_ID }}
           anthropic_organization_id: ${{ vars.ANTHROPIC_ORGANIZATION_ID }}
           anthropic_service_account_id: ${{ vars.ANTHROPIC_SERVICE_ACCOUNT_ID }}


### PR DESCRIPTION
## Summary

- Adds `allowed_bots: "mintlify,github-actions"` to the `claude-code-action` step in `doc-review.yml`
- Without this, PRs opened by bot accounts (e.g. Mintlify's automated PRs) fail with: `Workflow initiated by non-human actor: mintlify (type: Bot). Add bot to allowed_bots list or use '*' to allow all bots.`
- Using explicit bot names rather than `*` to avoid exposing the action to arbitrary external bots on this public repo

## Test plan

- [x] Merge this PR
- [x] Confirm the next bot-created PR (e.g. a Mintlify update) passes the doc-review check