### PR TITLE
docs: scope the boolean flags FAQ to pre-v2.36.0 CLIs

### DIFF
--- a/faq/faq.md
+++ b/faq/faq.md
@@ -100,22 +100,19 @@ Archiving policies isn't available yet. If this is something you'd find useful, 
 
 Flags with values can usually be specified with an `=` or with a **space** as a separator.
 For example, `--artifact-type=file` or `--artifact-type file`.
-However, an explicitly specified boolean flag value **must** use an `=`.
-For example, if you try this:
+Boolean flags accept both forms from CLI v2.36.0 onwards:
 ```
-kosli attest generic Dockerfile --artifact-type file  --compliant true ...
+kosli attest generic Dockerfile --artifact-type file --compliant false ...
 ```
-You will get an error stating:
+On earlier versions an explicitly specified boolean flag value **must** use an `=`.
+Either upgrade the CLI, or write the flag as `--compliant=false`.
+Without the `=` the command above fails with:
 ```
 Error: accepts at most 1 arg(s), received 2
 ```
-Here, `--artifact-type file` is parsed as if it was `--artifact-type=file`, leaving:
+because `--compliant` is parsed as if *implicitly* defaulting to `--compliant=true`, leaving:
 ```
-kosli attest generic Dockerfile --compliant true ...
+kosli attest generic Dockerfile false ...
 ```
-Then `--compliant` is parsed as if *implicitly* defaulting to `--compliant=true`, leaving:
-```
-kosli attest generic Dockerfile true ...
-```
-The parser then sees `Dockerfile` and `true` as the two
+The parser then sees `Dockerfile` and `false` as the two
 arguments to `kosli attest generic`.


### PR DESCRIPTION
  CLI v2.36.0 accepts boolean flag values written with a space
  (kosli-dev/cli#1037), so the page's central claim, that an explicitly
  specified boolean value must use an "=", and its worked example were both
  wrong for anyone on a current CLI.

  Rewritten rather than removed, and the "Boolean flags" heading kept
  verbatim. CLI versions up to v2.35.0 still hardcode a link to the
  #boolean-flags anchor in the error they print, and those customers are
  exactly the ones the old explanation still serves, so the anchor has to
  keep resolving and the pre-v2.36.0 behaviour has to stay documented.

  The example now uses --compliant false, the case where the old parse
  silently inverted the caller's intent, instead of --compliant true where
  the stray argument changed nothing.