### PR TITLE
docs: add Kosli MCP server integration page

### DIFF
--- a/config/navigation.json
+++ b/config/navigation.json
@@ -177,7 +177,8 @@
             "integrations/ci_cd",
             "integrations/slack",
             "integrations/launchdarkly",
-            "integrations/sonar"
+            "integrations/sonar",
+            "integrations/mcp_server"
           ]
         }
       ]

--- a/integrations/mcp_server.md
+++ b/integrations/mcp_server.md
@@ -26,9 +26,7 @@ Rather than ship one tool per Kosli endpoint, the server generates a catalog of 
 | `execute_read_action` | Invoke any `GET` action by ID. Auto-allowed in MCP clients. |
 | `execute_write_action` | Invoke any `POST`, `PUT`, `PATCH`, or `DELETE` action by ID. Gated behind user approval. |
 
-The assistant first calls `search_actions` to find the right action ID and its parameter schema, then calls `execute_read_action` or `execute_write_action` with that ID. Both execute tools accept an optional `fields` array that limits the response to specific top-level fields, which keeps responses small and token usage down.
-
-The `org` path parameter defaults to `KOSLI_ORG` when it is not supplied.
+The assistant first calls `search_actions` to find the right action ID and its parameter schema, then calls `execute_read_action` or `execute_write_action` with that ID. Both `execute_*` tools accept an optional `fields` array that limits the response to specific top-level fields, which keeps responses small and token usage down.
 
 <Warning>
 `execute_write_action` creates, modifies, and deletes real resources in your Kosli organization. MCP clients gate these calls behind an approval prompt, and that prompt is the only checkpoint before the call is made. An assistant may choose the wrong action, or the right action with the wrong parameters, so read the action ID and parameters before approving. Treat deletions and anything touching service accounts or API keys with particular care.
@@ -94,7 +92,7 @@ The server reads its configuration from environment variables.
 | Variable | Required | Default | Notes |
 |----------|----------|---------|-------|
 | `KOSLI_API_TOKEN` | yes | - | `KOSLI_API_KEY` is accepted as a fallback. |
-| `KOSLI_ORG` | yes | - | Default org, used when an action does not supply an `org` path parameter. |
+| `KOSLI_ORG` | yes | - | Default org. Used as the `org` path parameter when an action does not supply one. |
 | `KOSLI_BASE_URL` | no | `https://app.kosli.com` | Use `https://app.us.kosli.com` for US, or your own single-tenant endpoint. |
 
 ## Example prompts

--- a/integrations/mcp_server.md
+++ b/integrations/mcp_server.md
@@ -36,7 +36,7 @@ These are the tool names your client shows as the assistant works, and the name 
 
 - Node.js v22 or higher, for the `npx`-based install methods. You do not need it for the `.mcpb` bundle, because Claude Desktop ships its own Node runtime.
 - A Kosli API key. Use a [personal API key](/user/personal_api_keys) when you run the server on your own machine, or a [service account key](/administration/authentication/service_accounts) for automation.
-- An MCP-capable client, such as Claude Code or Claude Desktop
+- An MCP-capable client, such as Claude Code or Claude Desktop.
 
 ## Install
 

--- a/integrations/mcp_server.md
+++ b/integrations/mcp_server.md
@@ -26,7 +26,7 @@ Rather than ship one tool per Kosli endpoint, the server generates a catalog of 
 | `execute_read_action` | Invoke any `GET` action by ID. Auto-allowed in MCP clients. |
 | `execute_write_action` | Invoke any `POST`, `PUT`, `PATCH`, or `DELETE` action by ID. Gated behind user approval. |
 
-The assistant first calls `search_actions` to find the right action ID and its parameter schema, then calls `execute_read_action` or `execute_write_action` with that ID. Both `execute_*` tools accept an optional `fields` array that limits the response to specific top-level fields, which keeps responses small and token usage down.
+These are the tool names your client shows as the assistant works, and the name in the prompt when it asks you to approve a write.
 
 <Warning>
 `execute_write_action` creates, modifies, and deletes real resources in your Kosli organization. MCP clients gate these calls behind an approval prompt, and that prompt is the only checkpoint before the call is made. An assistant may choose the wrong action, or the right action with the wrong parameters, so read the action ID and parameters before approving. Treat deletions and anything touching service accounts or API keys with particular care.

--- a/integrations/mcp_server.md
+++ b/integrations/mcp_server.md
@@ -1,0 +1,128 @@
+---
+title: MCP server
+description: Connect AI assistants such as Claude Code and Claude Desktop to the Kosli API using the Model Context Protocol.
+tag: "BETA"
+---
+
+The Kosli MCP server is a [Model Context Protocol](https://modelcontextprotocol.io) server that exposes the Kosli API to AI assistants. Once it is connected, you can ask questions like _"which environments are non-compliant, and why?"_ and the assistant calls the relevant Kosli endpoints to answer.
+
+It is published from [`kosli-dev/mcp-server`](https://github.com/kosli-dev/mcp-server) and distributed as an npm package (`@kosli/mcp-server`) and as a `.mcpb` bundle for Claude Desktop.
+
+<Warning>
+The Kosli MCP server is in beta. Tool names, parameters, and behavior may change between releases. Pin a version if you need stability: `npx -y @kosli/mcp-server@0.5.0`.
+</Warning>
+
+<Note>
+This server reads the data in your Kosli organization. To let an AI assistant search this documentation instead, see [AI access to these docs](/understand_kosli/ai_docs_access). The two are complementary, and you can connect both.
+</Note>
+
+## How it works
+
+Rather than ship one tool per Kosli endpoint, the server generates a catalog of actions from Kosli's OpenAPI spec and exposes three generic tools:
+
+| Tool | Purpose |
+|------|---------|
+| `search_actions` | Fuzzy-search the catalog for relevant actions by natural-language query. |
+| `execute_read_action` | Invoke any `GET` action by ID. Auto-allowed in MCP clients. |
+| `execute_write_action` | Invoke any `POST`, `PUT`, `PATCH`, or `DELETE` action by ID. Gated behind user approval. |
+
+The assistant first calls `search_actions` to find the right action ID and its parameter schema, then calls `execute_read_action` or `execute_write_action` with that ID. Both execute tools accept an optional `fields` array that limits the response to specific top-level fields, which keeps responses small and token usage down.
+
+The `org` path parameter defaults to `KOSLI_ORG` when it is not supplied.
+
+<Warning>
+`execute_write_action` creates, modifies, and deletes real resources in your Kosli organization. MCP clients gate these calls behind an approval prompt, and that prompt is the only checkpoint before the call is made. An assistant may choose the wrong action, or the right action with the wrong parameters, so read the action ID and parameters before approving. Treat deletions and anything touching service accounts or API keys with particular care.
+</Warning>
+
+## Prerequisites
+
+- Node.js v22 or higher
+- A Kosli API key. Use a [personal API key](/user/personal_api_keys) when you run the server on your own machine, or a [service account key](/administration/authentication/service_accounts) for automation.
+- An MCP-capable client, such as Claude Code or Claude Desktop
+
+## Install
+
+<Tabs>
+  <Tab title="Claude Code">
+    Run this from your project directory, or add `--scope user` to install it globally:
+
+    ```bash
+    claude mcp add kosli \
+      -e KOSLI_API_TOKEN=your-token \
+      -e KOSLI_ORG=your-org \
+      -- npx -y @kosli/mcp-server
+    ```
+  </Tab>
+  <Tab title="Claude Desktop (.mcpb)">
+    Download the latest `.mcpb` file from the [releases page](https://github.com/kosli-dev/mcp-server/releases) and drag it into Claude Desktop, or double-click it to install. Claude Desktop prompts you for your API key and organization, and stores the secrets in your operating system keychain.
+
+    This is the recommended method for Claude Desktop.
+
+    <Note>
+      Extensions installed from a file show an "unverified by Anthropic" warning and do not auto-update, so you need to download and reinstall new versions manually. Both limitations go away once the extension is listed in Anthropic's [Connectors Directory](https://claude.com/docs/connectors/building/submission).
+    </Note>
+  </Tab>
+  <Tab title="Claude Desktop (manual)">
+    Add the following to `claude_desktop_config.json`, which you can open from **Settings → Developer → Edit Config**:
+
+    ```json
+    {
+      "mcpServers": {
+        "kosli": {
+          "command": "npx",
+          "args": ["-y", "@kosli/mcp-server"],
+          "env": {
+            "KOSLI_API_TOKEN": "your-token",
+            "KOSLI_ORG": "your-org"
+          }
+        }
+      }
+    }
+    ```
+
+    This method auto-updates through `npx` on each restart, but stores your API key in plain text.
+  </Tab>
+  <Tab title="Other MCP clients">
+    The server communicates over stdio. Point any MCP-capable client at the package with `npx -y @kosli/mcp-server` and set the environment variables below.
+  </Tab>
+</Tabs>
+
+## Configuration
+
+The server reads its configuration from environment variables.
+
+| Variable | Required | Default | Notes |
+|----------|----------|---------|-------|
+| `KOSLI_API_TOKEN` | yes | - | `KOSLI_API_KEY` is accepted as a fallback. |
+| `KOSLI_ORG` | yes | - | Default org, used when an action does not supply an `org` path parameter. |
+| `KOSLI_BASE_URL` | no | `https://app.kosli.com` | Use `https://app.us.kosli.com` for US, or your own single-tenant endpoint. |
+
+## Example prompts
+
+These prompts only read data, so they run without an approval step. Replace the environment, flow, and trail names with your own.
+
+### Environments and compliance
+
+- "Which of my environments are non-compliant, and why?"
+- "What is running in `prod-aws` right now?"
+- "Has anything changed in `prod-aws` since yesterday?"
+
+The assistant answers these from [environment snapshots](/getting_started/environments), so it can report both the current state and the reasons an environment is not compliant.
+
+### Audit and evidence
+
+- "List every deployment to `prod-aws` in the last 30 days."
+- "What attestations are on trail `release-456` in flow `my-release`?"
+- "Which artifacts running in `prod-aws` have no security scan attestation?"
+
+The last prompt takes several tool calls, because the assistant has to list what is running and then check the [attestations](/getting_started/attestations) on each artifact. Expect it to be slower than a single lookup, and check the artifact list it worked from before relying on the answer.
+
+## Limitations
+
+- The action catalog is generated from a snapshot of the OpenAPI spec. New endpoints become available when the catalog is regenerated and a new version of the package is published.
+- Ambiguous questions may take several `search_actions` calls before the assistant settles on the right action.
+- Responses are whatever the Kosli API returns. Large responses consume a lot of context, so ask for specific fields when you can.
+
+## Feedback
+
+The server is in beta and we want to hear how it works for you. Email [support@kosli.com](mailto:support@kosli.com) or open an issue in [`kosli-dev/mcp-server`](https://github.com/kosli-dev/mcp-server/issues).

--- a/integrations/mcp_server.md
+++ b/integrations/mcp_server.md
@@ -34,7 +34,7 @@ These are the tool names your client shows as the assistant works, and the name 
 
 ## Prerequisites
 
-- Node.js v22 or higher. This applies to every install method, including the `.mcpb` bundle, which declares the same requirement in its extension manifest.
+- Node.js v22 or higher, for the `npx`-based install methods. You do not need it for the `.mcpb` bundle, because Claude Desktop ships its own Node runtime.
 - A Kosli API key. Use a [personal API key](/user/personal_api_keys) when you run the server on your own machine, or a [service account key](/administration/authentication/service_accounts) for automation.
 - An MCP-capable client, such as Claude Code or Claude Desktop
 

--- a/integrations/mcp_server.md
+++ b/integrations/mcp_server.md
@@ -34,7 +34,7 @@ These are the tool names your client shows as the assistant works, and the name 
 
 ## Prerequisites
 
-- Node.js v22 or higher
+- Node.js v22 or higher. This applies to every install method, including the `.mcpb` bundle, which declares the same requirement in its extension manifest.
 - A Kosli API key. Use a [personal API key](/user/personal_api_keys) when you run the server on your own machine, or a [service account key](/administration/authentication/service_accounts) for automation.
 - An MCP-capable client, such as Claude Code or Claude Desktop
 

--- a/understand_kosli/ai_docs_access.md
+++ b/understand_kosli/ai_docs_access.md
@@ -5,6 +5,10 @@ description: 'Use MCP servers, skill.md, and llms.txt to let AI tools read and s
 
 Kosli documentation supports AI-friendly access through three mechanisms: an **MCP server** for semantic search, a **skill.md** endpoint that teaches AI assistants how the docs are organized, and **llms.txt** files that provide full documentation content. These let you query Kosli documentation directly from AI coding assistants like Cursor, Claude Code, Windsurf, VS Code with Copilot, and others.
 
+<Note>
+Everything on this page covers access to the documentation. To let an AI assistant query the data in your own Kosli organization, see the [Kosli MCP server](/integrations/mcp_server).
+</Note>
+
 ## MCP server
 
 The Model Context Protocol (MCP) server lets AI tools search Kosli documentation semantically. Instead of copy-pasting docs into a chat window, you connect your AI assistant to the MCP endpoint and it can search the docs on its own.


### PR DESCRIPTION
## What

Adds a documentation page for the [Kosli MCP server](https://github.com/kosli-dev/mcp-server), which exposes the Kosli API to AI assistants over the Model Context Protocol.

## Changes

- **`integrations/mcp_server.md`** (new) - install, configuration, how the three generic tools work, read-only example prompts, limitations.
- **`config/navigation.json`** - added to the Integrations group.
- **`understand_kosli/ai_docs_access.md`** - cross-link, so the docs MCP server and the API MCP server point at each other. One reads the documentation, the other reads your org's data.

## Updated against `v0.5.0`

The preview page had drifted from the server:

- Node floor raised from **v20 to v22**.
- Added the beta warning and version-pinning guidance (`npx -y @kosli/mcp-server@0.5.0`).
- Added a caution on `execute_write_action` - the client's approval prompt is the only checkpoint, and an assistant can select the wrong action, or the right action with the wrong parameters.
- Fixed a broken link: the old page pointed at `/getting_started/service-accounts`, which does not exist. Now links `/user/personal_api_keys` for local use and `/administration/authentication/service_accounts` for automation.

## Beta treatment

Uses `tag: "BETA"` in the front matter, matching the `client_reference/` pages, plus an inline `<Warning>`.

Deliberately *not* reusing `snippets/cli-beta-notice.mdx` - it ends with "Please contact us to enable this feature for your organization", which is untrue here: the server is a public npm package with nothing to enable.

## Verification

`mint broken-links` passes on everything touched here. It reports one **pre-existing** failure, left alone as out of scope:

```
tutorials/working_with_controls.mdx
 ⎿  /getting_started/service-accounts
```

That is the same bad path the old preview page carried. Happy to fix it in a follow-up.
